### PR TITLE
Enhance error validation message for compositions

### DIFF
--- a/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/composition/InvalidCompositionDtoGetterGenerator.java
+++ b/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/composition/InvalidCompositionDtoGetterGenerator.java
@@ -7,18 +7,25 @@ import static com.github.muehmar.gradle.openapi.generator.java.model.name.Method
 import static com.github.muehmar.gradle.openapi.generator.java.model.name.MethodNames.Composition.CompositionType.ANY_OF;
 import static com.github.muehmar.gradle.openapi.generator.java.model.name.MethodNames.Composition.CompositionType.ONE_OF;
 import static com.github.muehmar.gradle.openapi.generator.java.model.name.MethodNames.Composition.OneOf.getOneOfValidCountMethodName;
-import static com.github.muehmar.gradle.openapi.generator.java.model.name.MethodNames.Composition.getInvalidCompositionDtosMethodName;
+import static com.github.muehmar.gradle.openapi.generator.java.model.name.MethodNames.Composition.asConversionMethodName;
+import static com.github.muehmar.gradle.openapi.generator.java.model.name.MethodNames.Composition.getInvalidCompositionMethodName;
 import static io.github.muehmar.codegenerator.Generator.constant;
 
+import ch.bluecare.commons.data.NonEmptyList;
 import com.github.muehmar.gradle.openapi.generator.java.JavaRefs;
 import com.github.muehmar.gradle.openapi.generator.java.generator.shared.Filters;
 import com.github.muehmar.gradle.openapi.generator.java.generator.shared.SettingsFunctions;
 import com.github.muehmar.gradle.openapi.generator.java.generator.shared.ValidationGenerator;
+import com.github.muehmar.gradle.openapi.generator.java.model.composition.JavaDiscriminator;
+import com.github.muehmar.gradle.openapi.generator.java.model.composition.JavaOneOfComposition;
 import com.github.muehmar.gradle.openapi.generator.java.model.name.MethodNames;
 import com.github.muehmar.gradle.openapi.generator.java.model.pojo.JavaObjectPojo;
 import com.github.muehmar.gradle.openapi.generator.settings.PojoSettings;
 import io.github.muehmar.codegenerator.Generator;
 import io.github.muehmar.codegenerator.java.JavaGenerators;
+import java.util.Optional;
+import java.util.function.Function;
+import lombok.Value;
 
 public class InvalidCompositionDtoGetterGenerator {
   private InvalidCompositionDtoGetterGenerator() {}
@@ -30,36 +37,40 @@ public class InvalidCompositionDtoGetterGenerator {
         .append(invalidCompositionDtoGetter(ANY_OF));
   }
 
-  public static Generator<JavaObjectPojo, PojoSettings> invalidCompositionDtoGetter(
+  private static Generator<JavaObjectPojo, PojoSettings> invalidCompositionDtoGetter(
       MethodNames.Composition.CompositionType type) {
     final Generator<JavaObjectPojo, PojoSettings> method =
         JavaGenerators.<JavaObjectPojo, PojoSettings>methodGen()
             .modifiers(SettingsFunctions::validationMethodModifiers)
             .noGenericTypes()
-            .returnType("List<Object>")
-            .methodName(getInvalidCompositionDtosMethodName(type).asString())
+            .returnType("Map<String, Object>")
+            .methodName(getInvalidCompositionMethodName(type).asString())
             .noArguments()
             .content(invalidCompositionDtoGetterContent(type))
             .build()
-            .append(ref(JavaRefs.JAVA_UTIL_LIST))
-            .append(ref(JavaRefs.JAVA_UTIL_ARRAY_LIST));
+            .append(ref(JavaRefs.JAVA_UTIL_MAP))
+            .append(ref(JavaRefs.JAVA_UTIL_HASH_MAP));
 
     return Generator.<JavaObjectPojo, PojoSettings>emptyGen()
         .append(deprecatedValidationMethodJavaDoc())
         .append(ValidationGenerator.validAnnotation())
         .append(jsonIgnore())
         .append(method)
-        .filter(
-            p ->
-                (p.getOneOfComposition().isPresent() && type.equals(ONE_OF))
-                    || (p.getAnyOfComposition().isPresent() && type.equals(ANY_OF)))
+        .filter(p -> createInvalidCompositionDtoGetter(type, p))
         .filter(Filters.isValidationEnabled());
+  }
+
+  private static boolean createInvalidCompositionDtoGetter(
+      MethodNames.Composition.CompositionType type, JavaObjectPojo p) {
+    final boolean createForOneOf = p.getOneOfComposition().isPresent() && type.equals(ONE_OF);
+    final boolean createForAnyOf = p.getAnyOfComposition().isPresent() && type.equals(ANY_OF);
+    return createForOneOf || createForAnyOf;
   }
 
   private static Generator<JavaObjectPojo, PojoSettings> invalidCompositionDtoGetterContent(
       MethodNames.Composition.CompositionType type) {
     return Generator.<JavaObjectPojo, PojoSettings>emptyGen()
-        .append(constant("final List<Object> dtos = new ArrayList<>();"))
+        .append(constant("final Map<String, Object> dtos = new HashMap<>();"))
         .append(addInvalidOneOfDtos().filter(ignore -> type.equals(ONE_OF)))
         .append(addInvalidAnyOfDtos().filter(ignore -> type.equals(ANY_OF)))
         .append(constant("return dtos;"));
@@ -68,23 +79,80 @@ public class InvalidCompositionDtoGetterGenerator {
   private static Generator<JavaObjectPojo, PojoSettings> addInvalidOneOfDtos() {
     return Generator.<JavaObjectPojo, PojoSettings>emptyGen()
         .append(w -> w.println("if(%s() != 1) {", getOneOfValidCountMethodName()))
-        .appendList(addSingleInvalidDto(), JavaObjectPojo::getOneOfPojos)
+        .appendOptional(
+            oneOfDiscriminatorHandling().indent(1), DiscriminatorAndMemberPojo::fromParentPojo)
+        .appendList(putSingleInvalidDto(), JavaObjectPojo::getOneOfPojos)
         .append(constant("}"))
         .filter(pojo -> pojo.getOneOfComposition().isPresent());
+  }
+
+  private static Generator<NonEmptyList<DiscriminatorAndMemberPojo>, PojoSettings>
+      oneOfDiscriminatorHandling() {
+    final Generator<DiscriminatorAndMemberPojo, PojoSettings> singleCaseStatement =
+        Generator.<DiscriminatorAndMemberPojo, PojoSettings>emptyGen()
+            .append(
+                (dm, s, w) ->
+                    w.println("case \"%s\":", dm.getMemberPojo().getSchemaName().getOriginalName()))
+            .append(
+                (dm, s, w) ->
+                    w.tab(1)
+                        .println(
+                            "dtos.put(\"%s\", %s());",
+                            dm.getMemberPojo().getSchemaName().getOriginalName(),
+                            asConversionMethodName(dm.getMemberPojo())))
+            .append(constant("return dtos;"), 1)
+            .indent(2);
+    return Generator.<NonEmptyList<DiscriminatorAndMemberPojo>, PojoSettings>emptyGen()
+        .append(
+            (l, s, w) ->
+                w.println("if(%s != null) {", l.head().getDiscriminator().getPropertyName()))
+        .append(
+            (l, s, w) ->
+                w.tab(1).println("switch(%s) {", l.head().getDiscriminator().getPropertyName()))
+        .appendList(singleCaseStatement, Function.identity())
+        .append(constant("}"), 1)
+        .append(constant("}"));
   }
 
   private static Generator<JavaObjectPojo, PojoSettings> addInvalidAnyOfDtos() {
     return Generator.<JavaObjectPojo, PojoSettings>emptyGen()
         .append(constant("if(%s() == 0) {", getAnyOfValidCountMethodName()))
-        .appendList(addSingleInvalidDto(), JavaObjectPojo::getAnyOfPojos)
+        .appendList(putSingleInvalidDto(), JavaObjectPojo::getAnyOfPojos)
         .append(constant("}"))
         .filter(pojo -> pojo.getAnyOfComposition().isPresent());
   }
 
-  private static Generator<JavaObjectPojo, PojoSettings> addSingleInvalidDto() {
+  private static Generator<JavaObjectPojo, PojoSettings> putSingleInvalidDto() {
     return Generator.<JavaObjectPojo, PojoSettings>of(
             (p, s, w) ->
-                w.println("dtos.add(%s());", MethodNames.Composition.asConversionMethodName(p)))
+                w.println(
+                    "dtos.put(\"%s\", %s());",
+                    p.getSchemaName().getOriginalName(), asConversionMethodName(p)))
         .indent(1);
+  }
+
+  @Value
+  private static class DiscriminatorAndMemberPojo {
+    JavaDiscriminator discriminator;
+    JavaObjectPojo memberPojo;
+
+    public static Optional<NonEmptyList<DiscriminatorAndMemberPojo>> fromParentPojo(
+        JavaObjectPojo pojo) {
+      return pojo.getOneOfComposition().flatMap(DiscriminatorAndMemberPojo::fromComposition);
+    }
+
+    private static Optional<NonEmptyList<DiscriminatorAndMemberPojo>> fromComposition(
+        JavaOneOfComposition composition) {
+      return composition
+          .getDiscriminator()
+          .map(discriminator -> fromDiscriminator(composition, discriminator));
+    }
+
+    private static NonEmptyList<DiscriminatorAndMemberPojo> fromDiscriminator(
+        JavaOneOfComposition composition, JavaDiscriminator discriminator) {
+      return composition
+          .getPojos()
+          .map(memberPojo -> new DiscriminatorAndMemberPojo(discriminator, memberPojo));
+    }
   }
 }

--- a/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/java/model/name/MethodNames.java
+++ b/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/java/model/name/MethodNames.java
@@ -37,8 +37,8 @@ public class MethodNames {
       return JavaName.fromString(String.format("get%sValidCount", type.asString()));
     }
 
-    public static JavaName getInvalidCompositionDtosMethodName(CompositionType type) {
-      return JavaName.fromString(String.format("getInvalid%sDtos", type.asString()));
+    public static JavaName getInvalidCompositionMethodName(CompositionType type) {
+      return JavaName.fromString(String.format("getInvalid%s", type.asString()));
     }
 
     public static class OneOf {

--- a/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/__snapshots__/ObjectPojoGeneratorTest.snap
+++ b/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/__snapshots__/ObjectPojoGeneratorTest.snap
@@ -625,11 +625,11 @@ public class PersonDto {
 
   @Valid
   @JsonIgnore
-  private List<Object> getInvalidAnyOfDtos() {
-    final List<Object> dtos = new ArrayList<>();
+  private Map<String, Object> getInvalidAnyOf() {
+    final Map<String, Object> dtos = new HashMap<>();
     if(getAnyOfValidCount() == 0) {
-      dtos.add(asAdminDto());
-      dtos.add(asUserDto());
+      dtos.put("Admin", asAdminDto());
+      dtos.put("User", asUserDto());
     }
     return dtos;
   }
@@ -6561,10 +6561,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -6746,11 +6744,11 @@ public class PersonDto {
 
   @Valid
   @JsonIgnore
-  private List<Object> getInvalidOneOfDtos() {
-    final List<Object> dtos = new ArrayList<>();
+  private Map<String, Object> getInvalidOneOf() {
+    final Map<String, Object> dtos = new HashMap<>();
     if(getOneOfValidCount() != 1) {
-      dtos.add(asAdminDto());
-      dtos.add(asUserDto());
+      dtos.put("Admin", asAdminDto());
+      dtos.put("User", asUserDto());
     }
     return dtos;
   }

--- a/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/composition/InvalidCompositionDtoGetterGeneratorTest.java
+++ b/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/composition/InvalidCompositionDtoGetterGeneratorTest.java
@@ -12,8 +12,11 @@ import au.com.origin.snapshots.Expect;
 import au.com.origin.snapshots.annotations.SnapshotName;
 import ch.bluecare.commons.data.NonEmptyList;
 import com.github.muehmar.gradle.openapi.generator.java.model.composition.JavaOneOfComposition;
+import com.github.muehmar.gradle.openapi.generator.java.model.composition.JavaOneOfCompositions;
 import com.github.muehmar.gradle.openapi.generator.java.model.pojo.JavaObjectPojo;
 import com.github.muehmar.gradle.openapi.generator.java.model.pojo.JavaPojos;
+import com.github.muehmar.gradle.openapi.generator.model.Discriminator;
+import com.github.muehmar.gradle.openapi.generator.model.name.Name;
 import com.github.muehmar.gradle.openapi.generator.settings.PojoSettings;
 import com.github.muehmar.gradle.openapi.snapshot.SnapshotTest;
 import io.github.muehmar.codegenerator.Generator;
@@ -34,6 +37,26 @@ class InvalidCompositionDtoGetterGeneratorTest {
     final Writer writer =
         generator.generate(
             JavaPojos.oneOfPojo(sampleObjectPojo1(), sampleObjectPojo2()),
+            defaultTestSettings(),
+            javaWriter());
+
+    expect.toMatchSnapshot(writerSnapshot(writer));
+  }
+
+  @Test
+  @SnapshotName("oneOfPojoWithDiscriminator")
+  void generate_when_oneOfPojoWithDiscriminator_then_correctOutput() {
+    final Generator<JavaObjectPojo, PojoSettings> generator =
+        invalidCompositionDtoGetterGenerator();
+
+    final JavaOneOfComposition oneOfComposition =
+        JavaOneOfCompositions.fromPojosAndDiscriminator(
+            NonEmptyList.of(sampleObjectPojo1(), sampleObjectPojo2()),
+            Discriminator.fromPropertyName(Name.ofString("type")));
+
+    final Writer writer =
+        generator.generate(
+            JavaPojos.objectPojo().withOneOfComposition(Optional.of(oneOfComposition)),
             defaultTestSettings(),
             javaWriter());
 

--- a/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/composition/__snapshots__/InvalidCompositionDtoGetterGeneratorTest.snap
+++ b/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/composition/__snapshots__/InvalidCompositionDtoGetterGeneratorTest.snap
@@ -1,27 +1,27 @@
 anyOfAndOneOfPojo=[
 com.fasterxml.jackson.annotation.JsonIgnore
-java.util.ArrayList
-java.util.List
+java.util.HashMap
+java.util.Map
 javax.validation.Valid
 
 @Valid
 @JsonIgnore
-private List<Object> getInvalidOneOfDtos() {
-  final List<Object> dtos = new ArrayList<>();
+private Map<String, Object> getInvalidOneOf() {
+  final Map<String, Object> dtos = new HashMap<>();
   if(getOneOfValidCount() != 1) {
-    dtos.add(asSampleObjectPojo1Dto());
-    dtos.add(asSampleObjectPojo2Dto());
+    dtos.put("SampleObjectPojo1", asSampleObjectPojo1Dto());
+    dtos.put("SampleObjectPojo2", asSampleObjectPojo2Dto());
   }
   return dtos;
 }
 
 @Valid
 @JsonIgnore
-private List<Object> getInvalidAnyOfDtos() {
-  final List<Object> dtos = new ArrayList<>();
+private Map<String, Object> getInvalidAnyOf() {
+  final Map<String, Object> dtos = new HashMap<>();
   if(getAnyOfValidCount() == 0) {
-    dtos.add(asSampleObjectPojo1Dto());
-    dtos.add(asSampleObjectPojo2Dto());
+    dtos.put("SampleObjectPojo1", asSampleObjectPojo1Dto());
+    dtos.put("SampleObjectPojo2", asSampleObjectPojo2Dto());
   }
   return dtos;
 }
@@ -30,18 +30,18 @@ private List<Object> getInvalidAnyOfDtos() {
 
 anyOfPojo=[
 com.fasterxml.jackson.annotation.JsonIgnore
-java.util.ArrayList
-java.util.List
+java.util.HashMap
+java.util.Map
 javax.validation.Valid
 .
 .
 @Valid
 @JsonIgnore
-private List<Object> getInvalidAnyOfDtos() {
-  final List<Object> dtos = new ArrayList<>();
+private Map<String, Object> getInvalidAnyOf() {
+  final Map<String, Object> dtos = new HashMap<>();
   if(getAnyOfValidCount() == 0) {
-    dtos.add(asSampleObjectPojo1Dto());
-    dtos.add(asSampleObjectPojo2Dto());
+    dtos.put("SampleObjectPojo1", asSampleObjectPojo1Dto());
+    dtos.put("SampleObjectPojo2", asSampleObjectPojo2Dto());
   }
   return dtos;
 }
@@ -50,17 +50,47 @@ private List<Object> getInvalidAnyOfDtos() {
 
 oneOfPojo=[
 com.fasterxml.jackson.annotation.JsonIgnore
-java.util.ArrayList
-java.util.List
+java.util.HashMap
+java.util.Map
 javax.validation.Valid
 
 @Valid
 @JsonIgnore
-private List<Object> getInvalidOneOfDtos() {
-  final List<Object> dtos = new ArrayList<>();
+private Map<String, Object> getInvalidOneOf() {
+  final Map<String, Object> dtos = new HashMap<>();
   if(getOneOfValidCount() != 1) {
-    dtos.add(asSampleObjectPojo1Dto());
-    dtos.add(asSampleObjectPojo2Dto());
+    dtos.put("SampleObjectPojo1", asSampleObjectPojo1Dto());
+    dtos.put("SampleObjectPojo2", asSampleObjectPojo2Dto());
+  }
+  return dtos;
+}
+
+]
+
+
+oneOfPojoWithDiscriminator=[
+com.fasterxml.jackson.annotation.JsonIgnore
+java.util.HashMap
+java.util.Map
+javax.validation.Valid
+
+@Valid
+@JsonIgnore
+private Map<String, Object> getInvalidOneOf() {
+  final Map<String, Object> dtos = new HashMap<>();
+  if(getOneOfValidCount() != 1) {
+    if(type != null) {
+      switch(type) {
+        case "SampleObjectPojo1":
+          dtos.put("SampleObjectPojo1", asSampleObjectPojo1Dto());
+          return dtos;
+        case "SampleObjectPojo2":
+          dtos.put("SampleObjectPojo2", asSampleObjectPojo2Dto());
+          return dtos;
+      }
+    }
+    dtos.put("SampleObjectPojo1", asSampleObjectPojo1Dto());
+    dtos.put("SampleObjectPojo2", asSampleObjectPojo2Dto());
   }
   return dtos;
 }


### PR DESCRIPTION
- Using a map instead of a list with the invalid DTO's will show
the name of the schema instead of
an index.
- In case of a discriminator and the corresponding property is
not null, only the respective
DTO gets added to the map.
In case the type does not
correspond to a schema,
all DTO's gets added.

Issue: #151