### PR TITLE
Fix serialisation of optional and nullable properties

### DIFF
--- a/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/getter/OptionalNullableGetter.java
+++ b/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/getter/OptionalNullableGetter.java
@@ -85,6 +85,7 @@ class OptionalNullableGetter {
         .append(JavaDocGenerators.deprecatedValidationMethodJavaDoc())
         .append(validationAnnotationsForMember())
         .append(deprecatedValidationMethod())
+        .append(jsonIgnore())
         .append(CommonGetter.rawGetterMethod())
         .filter(isValidationEnabled())
         .filter(option.validationFilter());

--- a/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/__snapshots__/ObjectPojoGeneratorTest.snap
+++ b/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/__snapshots__/ObjectPojoGeneratorTest.snap
@@ -3052,6 +3052,7 @@ public class Illegal_IdentifierDto {
     return isSwitchNull ? new JacksonNullContainer<>(switch_) : switch_;
   }
 
+  @JsonIgnore
   private String getSwitchRaw() {
     return switch_;
   }
@@ -3070,6 +3071,7 @@ public class Illegal_IdentifierDto {
     return isPoint_Null ? new JacksonNullContainer<>(point_) : point_;
   }
 
+  @JsonIgnore
   private String getPoint_Raw() {
     return point_;
   }
@@ -4654,6 +4656,7 @@ public class NecessityAndNullabilityDto {
   }
 
   @Pattern(regexp="Hello")
+  @JsonIgnore
   private String getOptionalNullableStringValRaw() {
     return optionalNullableStringVal;
   }

--- a/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/getter/__snapshots__/GetterGeneratorTest.snap
+++ b/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/getter/__snapshots__/GetterGeneratorTest.snap
@@ -21,6 +21,7 @@ private Object getOptionalNullableStringValJackson() {
 }
 
 @Pattern(regexp="Hello")
+@JsonIgnore
 private String getOptionalNullableStringValRaw() {
   return optionalNullableStringVal;
 }
@@ -80,6 +81,7 @@ private Object getPoint_Jackson() {
   return isPoint_Null ? new JacksonNullContainer<>(point_) : point_;
 }
 
+@JsonIgnore
 private String getPoint_Raw() {
   return point_;
 }
@@ -158,6 +160,7 @@ private Object getSwitchJackson() {
   return isSwitchNull ? new JacksonNullContainer<>(switch_) : switch_;
 }
 
+@JsonIgnore
 private String getSwitchRaw() {
   return switch_;
 }

--- a/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/getter/__snapshots__/OptionalNullableGetterTest.snap
+++ b/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/getter/__snapshots__/OptionalNullableGetterTest.snap
@@ -26,6 +26,7 @@ private Object getStringValJackson() {
  */
 @Pattern(regexp="Hello")
 @Deprecated
+@JsonIgnore
 public String getStringValRaw() {
   return stringVal;
 }
@@ -111,6 +112,7 @@ private Object getListValJackson() {
 }
 
 @Size(min = 5)
+@JsonIgnore
 private List<@Min(value = 5) @Max(value = 10) Integer> getListValRaw() {
   return listVal;
 }


### PR DESCRIPTION
- Ignore the validation method for serialisation which will get picked
up by jackson if it becomes public
cause of the configuration.

Issue: #174