### PR TITLE
Fix implicit object type detection

### DIFF
--- a/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/model/schema/NoTypeSchema.java
+++ b/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/model/schema/NoTypeSchema.java
@@ -25,6 +25,7 @@ public class NoTypeSchema implements OpenApiSchema {
         && schema.getTypes() == null
         && schema.getFormat() == null
         && schema.getProperties() == null
+        && schema.getRequired() == null
         && schema.getAdditionalProperties() == null
         && schema.get$ref() == null) {
 

--- a/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/model/schema/ObjectSchema.java
+++ b/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/model/schema/ObjectSchema.java
@@ -79,6 +79,9 @@ public class ObjectSchema implements OpenApiSchema {
     if (schema.getProperties() != null) {
       return true;
     }
+    if (schema.getRequired() != null) {
+      return true;
+    }
     if (schema.getAdditionalProperties() != null) {
       return true;
     }

--- a/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/model/schema/ObjectSchemaTest.java
+++ b/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/model/schema/ObjectSchemaTest.java
@@ -330,6 +330,24 @@ class ObjectSchemaTest {
   }
 
   @Test
+  void mapToPojo_when_schemaWithOnlyRequiredProperties_then_objectSchemaDetected() {
+    final Schema<Object> objectSchema = new Schema<>();
+    objectSchema.setRequired(Collections.singletonList("name"));
+    objectSchema.setDescription("Test description");
+
+    final ComponentName componentName = componentName("Object", "Dto");
+    final PojoSchema pojoSchema = new PojoSchema(componentName, objectSchema);
+
+    // method call
+    final MapContext mapContext = pojoSchema.mapToPojo();
+
+    final UnresolvedMapResult unresolvedMapResult = mapContext.getUnresolvedMapResult();
+    assertEquals(0, unresolvedMapResult.getPojos().size());
+    assertEquals(1, unresolvedMapResult.getUnresolvedObjectPojos().size());
+    assertEquals(0, unresolvedMapResult.getPojoMemberReferences().size());
+  }
+
+  @Test
   void mapToMemberType_when_mapSchemaWithReferenceInAdditionalProperties_then_correctType() {
     final MapSchema mapSchema = new MapSchema();
     final Schema<Object> additionalProperties = new Schema<>();


### PR DESCRIPTION
- If the schema contains required properties, it is considered implicitly
as object type

Issue: #208