### PR TITLE
Supported making nested properties required

### DIFF
--- a/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/mapper/resolver/MapResultResolverImpl.java
+++ b/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/mapper/resolver/MapResultResolverImpl.java
@@ -30,7 +30,9 @@ public class MapResultResolverImpl implements MapResultResolver {
             .map(this::addEnumDescription)
             .orElse(PList.empty());
     return MapResult.of(
-        resolvedPojos, unresolvedMapResult.getParameters(), unresolvedMapResult.getUsedSpecs());
+        NestedRequiredPropertyResolver.resolve(resolvedPojos),
+        unresolvedMapResult.getParameters(),
+        unresolvedMapResult.getUsedSpecs());
   }
 
   private PList<Pojo> inlineMemberReferences(

--- a/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/mapper/resolver/NestedRequiredPropertyResolver.java
+++ b/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/mapper/resolver/NestedRequiredPropertyResolver.java
@@ -1,0 +1,395 @@
+package com.github.muehmar.gradle.openapi.generator.mapper.resolver;
+
+import static com.github.muehmar.gradle.openapi.util.Booleans.not;
+
+import ch.bluecare.commons.data.NonEmptyList;
+import ch.bluecare.commons.data.PList;
+import com.github.muehmar.gradle.openapi.generator.model.Necessity;
+import com.github.muehmar.gradle.openapi.generator.model.Pojo;
+import com.github.muehmar.gradle.openapi.generator.model.PojoMember;
+import com.github.muehmar.gradle.openapi.generator.model.Type;
+import com.github.muehmar.gradle.openapi.generator.model.composition.AllOfComposition;
+import com.github.muehmar.gradle.openapi.generator.model.name.ComponentName;
+import com.github.muehmar.gradle.openapi.generator.model.name.Name;
+import com.github.muehmar.gradle.openapi.generator.model.name.PojoName;
+import com.github.muehmar.gradle.openapi.generator.model.pojo.ObjectPojo;
+import com.github.muehmar.gradle.openapi.generator.model.type.ObjectType;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import lombok.Value;
+
+public class NestedRequiredPropertyResolver {
+  private NestedRequiredPropertyResolver() {}
+
+  public static PList<Pojo> resolve(PList<Pojo> pojos) {
+    final PList<ObjectPojo> allObjectPojos =
+        pojos.flatMapOptional(
+            p -> p.fold(Optional::of, ignore -> Optional.empty(), ignore -> Optional.empty()));
+    return new Resolver(pojos, allObjectPojos).resolve();
+  }
+
+  private static class Resolver {
+    private final PList<Pojo> allPojos;
+    private final PList<ObjectPojo> allObjectPojos;
+
+    public Resolver(PList<Pojo> allPojos, PList<ObjectPojo> allObjectPojos) {
+      this.allPojos = allPojos;
+      this.allObjectPojos = allObjectPojos;
+    }
+
+    private PList<Pojo> resolve() {
+      final PList<Pojo> promotedPojos =
+          findRequiredPropertiesForPojos()
+              .flatMap(
+                  requiredPropertiesForPojo -> requiredPropertiesForPojo.promote(allObjectPojos))
+              .map(p -> p);
+      return allPojos.foldLeft(
+          promotedPojos,
+          (pojos, existingPojo) ->
+              pojos.exists(p -> p.getName().equals(existingPojo.getName()))
+                  ? pojos
+                  : pojos.cons(existingPojo));
+    }
+
+    private PList<RequiredPropertiesForPojo> findRequiredPropertiesForPojos() {
+      return allObjectPojos.flatMapOptional(
+          parentPojo ->
+              parentPojo
+                  .getAllOfComposition()
+                  .flatMap(
+                      allOfComposition ->
+                          allOfComposition
+                              .getPojos()
+                              .toPList()
+                              .flatMapOptional(Pojo::asObjectPojo)
+                              .flatMapOptional(
+                                  pojo ->
+                                      findRequiredPropertiesForAllOfPojo(
+                                          parentPojo, allOfComposition, pojo))
+                              .reduce(RequiredPropertiesForPojo::merge)));
+    }
+
+    private Optional<RequiredPropertiesForPojo> findRequiredPropertiesForAllOfPojo(
+        ObjectPojo parentPojo, AllOfComposition allOfComposition, ObjectPojo pojo) {
+      final PList<RequiredProperty> requiredProps = findRequiredProperties(pojo, allOfComposition);
+      if (requiredProps.nonEmpty()) {
+        return Optional.of(
+            new RequiredPropertiesForPojo(
+                parentPojo, PList.single(pojo), allOfComposition, requiredProps));
+      } else {
+        return Optional.empty();
+      }
+    }
+
+    private PList<RequiredProperty> findRequiredProperties(
+        ObjectPojo pojo, AllOfComposition allOfComposition) {
+      if (not(hasOnlyRequiredAdditionalProperties(pojo))) {
+        return PList.empty();
+      }
+
+      final PList<ObjectPojo> otherAllOfPojos =
+          allOfComposition
+              .getPojos()
+              .toPList()
+              .flatMapOptional(Pojo::asObjectPojo)
+              .filter(p -> not(p.equals(pojo)));
+      return findRequiredPropertiesDeep(pojo, PList.empty())
+          .filter(
+              requiredProperty ->
+                  otherAllOfPojos.exists(p -> hasPojoProperty(p, requiredProperty)));
+    }
+
+    private PList<RequiredProperty> findRequiredPropertiesDeep(
+        ObjectPojo currentPojo, PList<SinglePropertyLink> currentLinkChain) {
+      final boolean hasNonObjectProperties =
+          currentPojo
+              .getMembers()
+              .toStream()
+              .anyMatch(member -> not(member.getType().isObjectType()));
+      if (hasNonObjectProperties) {
+        return PList.empty();
+      }
+      if (currentLinkChain
+          .reverse()
+          .drop(1)
+          .reverse()
+          .exists(link -> link.getPojoName().equals(currentPojo.getName().getPojoName()))) {
+        return PList.empty();
+      }
+
+      final PList<RequiredProperty> requiredProperties =
+          currentPojo
+              .getMembers()
+              .flatMapOptional(member -> findRequiredPropertiesForMember(currentLinkChain, member))
+              .flatMap(list -> list);
+
+      return currentPojo
+          .getRequiredAdditionalProperties()
+          .concat(currentPojo.getMembers().filter(PojoMember::isRequired).map(PojoMember::getName))
+          .map(
+              requiredAdditionalProperty ->
+                  new RequiredProperty(requiredAdditionalProperty, currentLinkChain))
+          .concat(requiredProperties);
+    }
+
+    private Optional<PList<RequiredProperty>> findRequiredPropertiesForMember(
+        PList<SinglePropertyLink> currentLinkChain, PojoMember member) {
+      return member
+          .getType()
+          .asObjectType()
+          .flatMap(
+              objectType -> {
+                final SinglePropertyLink nextLink =
+                    new SinglePropertyLink(member.getName(), objectType.getName());
+                return findPojoForPojoName(objectType.getName())
+                    .map(
+                        nextPojo ->
+                            findRequiredPropertiesDeep(nextPojo, currentLinkChain.add(nextLink)));
+              });
+    }
+
+    private boolean hasOnlyRequiredAdditionalProperties(ObjectPojo pojo) {
+      final boolean hasNonObjectTypeProperties =
+          pojo.getMembers().toStream().anyMatch(member -> not(member.getType().isObjectType()));
+      if (hasNonObjectTypeProperties) {
+        return false;
+      }
+      if (pojo.getAllOfComposition().isPresent()) {
+        return false;
+      }
+      if (pojo.getOneOfComposition().isPresent()) {
+        return false;
+      }
+      if (pojo.getAnyOfComposition().isPresent()) {
+        return false;
+      }
+      if (not(pojo.getAdditionalProperties().isAllowed())
+          || not(pojo.getAdditionalProperties().getType().isAnyType())) {
+        return false;
+      }
+      return pojo.getMembers()
+          .flatMapOptional(member -> member.getType().asObjectType())
+          .flatMapOptional(objectType -> findPojoForPojoName(objectType.getName()))
+          .forall(this::hasOnlyRequiredAdditionalProperties);
+    }
+
+    private Optional<ObjectPojo> findPojoForPojoName(PojoName pojoName) {
+      return allObjectPojos.find(pojo -> pojo.getName().getPojoName().equals(pojoName));
+    }
+
+    private boolean hasPojoProperty(ObjectPojo pojo, RequiredProperty requiredProperty) {
+      return requiredProperty.resolveLink(pojo, allObjectPojos).isPresent();
+    }
+  }
+
+  @Value
+  private static class RequiredPropertiesForPojo {
+    ObjectPojo parentPojo;
+    PList<ObjectPojo> makeRequiredAllOfPojos;
+    AllOfComposition composition;
+    PList<RequiredProperty> requiredProperties;
+
+    RequiredPropertiesForPojo merge(RequiredPropertiesForPojo other) {
+      return new RequiredPropertiesForPojo(
+          parentPojo,
+          makeRequiredAllOfPojos.concat(other.makeRequiredAllOfPojos),
+          composition,
+          requiredProperties.concat(requiredProperties));
+    }
+
+    PList<PojoNode> toNodes(PList<ObjectPojo> allObjectPojos) {
+      return composition
+          .getPojos()
+          .toPList()
+          .flatMapOptional(Pojo::asObjectPojo)
+          .flatMapOptional(
+              allOfPojo ->
+                  requiredProperties
+                      .flatMapOptional(rp -> rp.toNodeFor(allOfPojo, allObjectPojos))
+                      .reduce(PojoNode::merge));
+    }
+
+    PList<ObjectPojo> promote(PList<ObjectPojo> allObjectPojos) {
+      final PList<PojoNode> nodes = toNodes(allObjectPojos);
+      final PList<ObjectPojo> objectPojos = promoteNodes(allObjectPojos, nodes);
+      final PList<Pojo> newAllOfPojos = createNewAllOfPojos(nodes, objectPojos);
+
+      final ObjectPojo promotedParentPojo =
+          NonEmptyList.fromIter(newAllOfPojos)
+              .map(AllOfComposition::fromPojos)
+              .map(Optional::of)
+              .map(parentPojo::withAllOfComposition)
+              .orElse(parentPojo);
+      return objectPojos.add(promotedParentPojo);
+    }
+
+    private PList<Pojo> createNewAllOfPojos(PList<PojoNode> nodes, PList<ObjectPojo> objectPojos) {
+      return composition
+          .getPojos()
+          .toPList()
+          .filter(p -> not(isMakeRequiredAllOfPojo(p)))
+          .map(
+              p -> {
+                if (nodes.exists(n -> n.getPojoName().equals(p.getName().getPojoName()))) {
+                  final Function<ComponentName, ComponentName> mapName =
+                      name -> mapComponentName(parentPojo.getName().getPojoName(), name);
+                  return objectPojos
+                      .find(promoted -> promoted.getName().equals(mapName.apply(p.getName())))
+                      .<Pojo>map(pj -> pj)
+                      .orElse(p);
+                } else {
+                  return p;
+                }
+              });
+    }
+
+    private PList<ObjectPojo> promoteNodes(
+        PList<ObjectPojo> allObjectPojos, PList<PojoNode> nodes) {
+      return nodes.flatMap(
+          node ->
+              node.promote(
+                  parentPojo.getName().getPojoName(),
+                  allObjectPojos.filter(
+                      p ->
+                          not(
+                              makeRequiredAllOfPojos
+                                  .map(ObjectPojo::getName)
+                                  .exists(p.getName()::equals)))));
+    }
+
+    private boolean isMakeRequiredAllOfPojo(Pojo p) {
+      return makeRequiredAllOfPojos.map(ObjectPojo::getName).exists(p.getName()::equals);
+    }
+  }
+
+  @Value
+  private static class RequiredProperty {
+    Name propertyName;
+    PList<SinglePropertyLink> linkChain;
+
+    RequiredProperty removeFirstLink() {
+      return new RequiredProperty(propertyName, linkChain.drop(1));
+    }
+
+    private Optional<ObjectPojo> resolveLink(
+        ObjectPojo currentPojo, PList<ObjectPojo> allObjectPojos) {
+      return linkChain
+          .foldLeft(
+              Optional.of(currentPojo),
+              (nextPojo, link) -> nextPojo.flatMap(p -> link.resolveLink(p, allObjectPojos)))
+          .filter(pojo -> pojo.getMembers().exists(m -> m.getName().equals(propertyName)));
+    }
+
+    Optional<PojoNode> toNodeFor(ObjectPojo pojo, PList<ObjectPojo> allObjectPojos) {
+      if (linkChain.isEmpty()) {
+        return pojo.getMembers().exists(pojoMember -> pojoMember.getName().equals(propertyName))
+            ? Optional.of(
+                new PojoNode(
+                    pojo.getName().getPojoName(),
+                    PList.single(propertyName),
+                    Collections.emptyMap()))
+            : Optional.empty();
+      } else {
+        return linkChain
+            .headOption()
+            .flatMap(
+                link ->
+                    link.resolveLink(pojo, allObjectPojos)
+                        .flatMap(
+                            nextPojo ->
+                                removeFirstLink()
+                                    .toNodeFor(nextPojo, allObjectPojos)
+                                    .map(
+                                        childNode ->
+                                            new PojoNode(
+                                                pojo.getName().getPojoName(),
+                                                PList.empty(),
+                                                Collections.singletonMap(
+                                                    link.propertyName, childNode)))));
+      }
+    }
+  }
+
+  @Value
+  private static class SinglePropertyLink {
+    Name propertyName;
+    PojoName pojoName;
+
+    private Optional<ObjectPojo> resolveLink(
+        ObjectPojo currentPojo, PList<ObjectPojo> allObjectPojos) {
+      return currentPojo
+          .getMembers()
+          .find(member -> member.getName().equals(propertyName))
+          .flatMap(member -> member.getType().asObjectType())
+          .flatMap(
+              objectType ->
+                  allObjectPojos.find(p -> p.getName().getPojoName().equals(objectType.getName())));
+    }
+  }
+
+  @Value
+  private static class PojoNode {
+    PojoName pojoName;
+    PList<Name> requiredProperties;
+    Map<Name, PojoNode> children;
+
+    PojoNode merge(PojoNode other) {
+      final HashMap<Name, PojoNode> newChildren = new HashMap<>(children);
+      other.children.forEach((name, child) -> newChildren.merge(name, child, PojoNode::merge));
+      return new PojoNode(
+          pojoName,
+          requiredProperties.concat(other.requiredProperties).distinct(Function.identity()),
+          newChildren);
+    }
+
+    PList<ObjectPojo> promote(PojoName rootPojoName, PList<ObjectPojo> allObjectPojos) {
+      return allObjectPojos
+          .find(pojo -> pojo.getName().getPojoName().equals(pojoName))
+          .map(
+              pojo -> {
+                final Function<ComponentName, ComponentName> mapName =
+                    name -> mapComponentName(rootPojoName, name);
+                final PList<PojoMember> members =
+                    pojo.getMembers()
+                        .map(this::promoteMember)
+                        .map(m -> renameObjectTypeNames(rootPojoName, m));
+                final ComponentName componentName = mapName.apply(pojo.getName());
+                return PList.fromIter(children.values())
+                    .flatMap(node -> node.promote(rootPojoName, allObjectPojos))
+                    .add(pojo.withName(componentName).withMembers(members));
+              })
+          .orElse(PList.empty());
+    }
+
+    private PojoMember promoteMember(PojoMember m) {
+      return requiredProperties.exists(m.getName()::equals)
+          ? m.withNecessity(Necessity.REQUIRED)
+          : m;
+    }
+
+    private PojoMember renameObjectTypeNames(PojoName rootPojoName, PojoMember member) {
+      final Type newType =
+          member
+              .getType()
+              .asObjectType()
+              .<Type>map(
+                  type ->
+                      ObjectType.ofName(
+                          rootPojoName.appendToName(type.getName().getName().asString())))
+              .orElse(member.getType());
+      return Optional.ofNullable(children.get(member.getName()))
+          .map(child -> member.withType(newType))
+          .orElse(member);
+    }
+  }
+
+  private static ComponentName mapComponentName(
+      PojoName rootPojoName, ComponentName originalComponentName) {
+    return new ComponentName(
+        rootPojoName.appendToName(originalComponentName.getPojoName().getName().asString()),
+        originalComponentName.getSchemaName());
+  }
+}

--- a/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/model/Type.java
+++ b/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/model/Type.java
@@ -57,6 +57,10 @@ public interface Type {
         ignore -> Optional.empty());
   }
 
+  default boolean isObjectType() {
+    return asObjectType().isPresent();
+  }
+
   default Optional<NumericType> asNumericType() {
     return fold(
         Optional::of,
@@ -132,5 +136,18 @@ public interface Type {
 
   default boolean isEnumType() {
     return asEnumType().isPresent();
+  }
+
+  default boolean isAnyType() {
+    return fold(
+        numericType -> false,
+        integerType -> false,
+        stringType -> false,
+        arrayType -> false,
+        booleanType -> false,
+        objectType -> false,
+        enumType -> false,
+        mapType -> false,
+        anyType -> true);
   }
 }

--- a/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/mapper/resolver/NestedRequiredPropertyResolverTest.java
+++ b/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/mapper/resolver/NestedRequiredPropertyResolverTest.java
@@ -1,0 +1,244 @@
+package com.github.muehmar.gradle.openapi.generator.mapper.resolver;
+
+import static com.github.muehmar.gradle.openapi.generator.model.Necessity.OPTIONAL;
+import static com.github.muehmar.gradle.openapi.generator.model.Necessity.REQUIRED;
+import static com.github.muehmar.gradle.openapi.generator.model.name.ComponentNames.componentName;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ch.bluecare.commons.data.NonEmptyList;
+import ch.bluecare.commons.data.PList;
+import com.github.muehmar.gradle.openapi.generator.model.Necessity;
+import com.github.muehmar.gradle.openapi.generator.model.Nullability;
+import com.github.muehmar.gradle.openapi.generator.model.Pojo;
+import com.github.muehmar.gradle.openapi.generator.model.PojoMember;
+import com.github.muehmar.gradle.openapi.generator.model.PojoMembers;
+import com.github.muehmar.gradle.openapi.generator.model.Pojos;
+import com.github.muehmar.gradle.openapi.generator.model.PropertyScope;
+import com.github.muehmar.gradle.openapi.generator.model.composition.AllOfComposition;
+import com.github.muehmar.gradle.openapi.generator.model.name.Name;
+import com.github.muehmar.gradle.openapi.generator.model.pojo.ObjectPojo;
+import com.github.muehmar.gradle.openapi.generator.model.type.IntegerType;
+import com.github.muehmar.gradle.openapi.generator.model.type.ObjectType;
+import com.github.muehmar.gradle.openapi.generator.model.type.StringType;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class NestedRequiredPropertyResolverTest {
+
+  private static final PojoMember FIRST_NAME =
+      new PojoMember(
+          Name.ofString("firstName"),
+          "firstName",
+          StringType.noFormat(),
+          PropertyScope.DEFAULT,
+          Necessity.OPTIONAL,
+          Nullability.NOT_NULLABLE);
+  private static final PojoMember MIDDLE_NAME =
+      new PojoMember(
+          Name.ofString("middleName"),
+          "middleName",
+          StringType.noFormat(),
+          PropertyScope.DEFAULT,
+          Necessity.OPTIONAL,
+          Nullability.NOT_NULLABLE);
+  private static final PojoMember LAST_NAME =
+      new PojoMember(
+          Name.ofString("lastName"),
+          "lastName",
+          StringType.noFormat(),
+          PropertyScope.DEFAULT,
+          REQUIRED,
+          Nullability.NOT_NULLABLE);
+  private static final PojoMember STREET =
+      new PojoMember(
+          Name.ofString("street"),
+          "street",
+          StringType.noFormat(),
+          PropertyScope.DEFAULT,
+          REQUIRED,
+          Nullability.NOT_NULLABLE);
+  private static final PojoMember HOUSR_NR =
+      new PojoMember(
+          Name.ofString("housenr"),
+          "housenr",
+          IntegerType.formatInteger(),
+          PropertyScope.DEFAULT,
+          Necessity.OPTIONAL,
+          Nullability.NOT_NULLABLE);
+  private static final PojoMember ZIP =
+      new PojoMember(
+          Name.ofString("zip"),
+          "zip",
+          IntegerType.formatInteger(),
+          PropertyScope.DEFAULT,
+          Necessity.OPTIONAL,
+          Nullability.NOT_NULLABLE);
+  private static final PojoMember CITY_CODE =
+      new PojoMember(
+          Name.ofString("cityCode"),
+          "cityCode",
+          IntegerType.formatInteger(),
+          PropertyScope.DEFAULT,
+          Necessity.OPTIONAL,
+          Nullability.NOT_NULLABLE);
+  private static final PojoMember CITY_NAME =
+      new PojoMember(
+          Name.ofString("cityName"),
+          "cityName",
+          IntegerType.formatInteger(),
+          PropertyScope.DEFAULT,
+          REQUIRED,
+          Nullability.NOT_NULLABLE);
+
+  @Test
+  void resolve_when_allOfPojoWithRequiredPropertiesPojo_then_correctResolved() {
+    final ObjectPojo cityDto =
+        Pojos.objectPojo(PList.of(ZIP, CITY_CODE, CITY_NAME))
+            .withName(componentName("City", "Dto"));
+    final ObjectPojo addressDto =
+        Pojos.objectPojo(
+                PList.of(
+                    STREET,
+                    HOUSR_NR,
+                    PojoMembers.ofType(ObjectType.ofName(cityDto.getName().getPojoName()))
+                        .withName(Name.ofString("city"))))
+            .withName(componentName("Address", "Dto"));
+    final ObjectPojo userDto =
+        Pojos.objectPojo(
+                PList.of(
+                    FIRST_NAME,
+                    MIDDLE_NAME,
+                    LAST_NAME,
+                    PojoMembers.ofType(ObjectType.ofName(addressDto.getName().getPojoName()))
+                        .withName(Name.ofString("address"))
+                        .withNecessity(OPTIONAL)))
+            .withName(componentName("User", "Dto"));
+
+    final ObjectPojo requiredCityPropsDto =
+        Pojos.objectPojo(PList.empty())
+            .withRequiredAdditionalProperties(PList.of(ZIP.getName()))
+            .withName(componentName("RequiredCityProps", "Dto"));
+
+    final ObjectPojo requiredAddressPropsDto =
+        Pojos.objectPojo(
+                PList.of(
+                    PojoMembers.ofType(
+                            ObjectType.ofName(requiredCityPropsDto.getName().getPojoName()))
+                        .withName(Name.ofString("city"))))
+            .withRequiredAdditionalProperties(PList.of(HOUSR_NR.getName()))
+            .withName(componentName("RequiredAddressProps", "Dto"));
+
+    final ObjectPojo requiredUserPropsDto =
+        Pojos.objectPojo(
+                PList.of(
+                    PojoMembers.ofType(
+                            ObjectType.ofName(requiredAddressPropsDto.getName().getPojoName()))
+                        .withNecessity(REQUIRED)
+                        .withName(Name.ofString("address"))))
+            .withRequiredAdditionalProperties(PList.of(FIRST_NAME.getName()))
+            .withName(componentName("RequiredUserProps", "Dto"));
+
+    final ObjectPojo updateUserDto =
+        Pojos.allOfPojo(userDto, requiredUserPropsDto).withName(componentName("UpdateUser", "Dto"));
+
+    // method call
+    final PList<Pojo> resolvedPojos =
+        NestedRequiredPropertyResolver.resolve(
+            PList.of(
+                cityDto,
+                addressDto,
+                userDto,
+                requiredCityPropsDto,
+                requiredAddressPropsDto,
+                requiredUserPropsDto,
+                updateUserDto));
+
+    assertEquals(
+        PList.of(
+                "UpdateUserUserDto",
+                "RequiredCityPropsDto",
+                "RequiredUserPropsDto",
+                "RequiredAddressPropsDto",
+                "UpdateUserDto",
+                "UpdateUserCityDto",
+                "UserDto",
+                "UpdateUserAddressDto",
+                "AddressDto",
+                "CityDto")
+            .toHashSet(),
+        resolvedPojos.map(p -> p.getName().getPojoName().asString()).toHashSet());
+
+    final ObjectPojo resolvedCityDto =
+        cityDto
+            .withMembers(PList.of(ZIP.withNecessity(REQUIRED), CITY_CODE, CITY_NAME))
+            .withName(componentName("UpdateUserCity", "Dto", "City"));
+    final ObjectPojo resolvedAddressDto =
+        addressDto
+            .withMembers(
+                PList.of(
+                    STREET,
+                    HOUSR_NR.withNecessity(REQUIRED),
+                    PojoMembers.ofType(ObjectType.ofName(resolvedCityDto.getName().getPojoName()))
+                        .withName(Name.ofString("city"))))
+            .withName(componentName("UpdateUserAddress", "Dto", "Address"));
+    final ObjectPojo resolvedUserDto =
+        userDto
+            .withMembers(
+                PList.of(
+                    FIRST_NAME.withNecessity(REQUIRED),
+                    MIDDLE_NAME,
+                    LAST_NAME,
+                    PojoMembers.ofType(
+                            ObjectType.ofName(resolvedAddressDto.getName().getPojoName()))
+                        .withNecessity(REQUIRED)
+                        .withName(Name.ofString("address"))))
+            .withName(componentName("UpdateUserUser", "Dto", "User"));
+    final ObjectPojo resolvedUpdateUserDto =
+        updateUserDto.withAllOfComposition(
+            Optional.of(AllOfComposition.fromPojos(NonEmptyList.single(resolvedUserDto))));
+
+    final ObjectPojo actualResolvedUpdateUser = findObjectPojo(resolvedPojos, "UpdateUser");
+    assertEquals(resolvedUpdateUserDto, actualResolvedUpdateUser);
+
+    final ObjectPojo actualResolvedUser = findObjectPojo(resolvedPojos, "UpdateUserUser");
+    assertEquals(resolvedUserDto, actualResolvedUser);
+
+    final ObjectPojo actualResolvedAddress = findObjectPojo(resolvedPojos, "UpdateUserAddress");
+    assertEquals(resolvedAddressDto, actualResolvedAddress);
+
+    final ObjectPojo actualResolvedCity = findObjectPojo(resolvedPojos, "UpdateUserCity");
+    assertEquals(resolvedCityDto, actualResolvedCity);
+  }
+
+  @Test
+  void resolve_when_noPropertyGetsPromoted_then_noChanges() {
+    final ObjectPojo userDto =
+        Pojos.objectPojo(PList.of(FIRST_NAME, MIDDLE_NAME, LAST_NAME))
+            .withName(componentName("User", "Dto"));
+    final ObjectPojo requiredAdditionalPropertiesDto =
+        Pojos.objectPojo(PList.empty())
+            .withRequiredAdditionalProperties(PList.of(STREET.getName()))
+            .withName(componentName("RequiredAddProp", "Dto"));
+    final ObjectPojo parentPojo =
+        Pojos.allOfPojo(userDto, requiredAdditionalPropertiesDto)
+            .withName(componentName("Parent", "Dto"));
+
+    final PList<Pojo> resolvedPojos =
+        NestedRequiredPropertyResolver.resolve(
+            PList.of(userDto, requiredAdditionalPropertiesDto, parentPojo));
+
+    assertEquals(
+        PList.of(userDto, requiredAdditionalPropertiesDto, parentPojo).toHashSet(),
+        resolvedPojos.toHashSet());
+  }
+
+  private static ObjectPojo findObjectPojo(PList<Pojo> pojos, String pojoName) {
+    final Optional<ObjectPojo> objectPojo =
+        pojos
+            .flatMapOptional(Pojo::asObjectPojo)
+            .find(pojo -> pojo.getName().getPojoName().getName().asString().equals(pojoName));
+    assertTrue(objectPojo.isPresent(), "No object pojo found with name " + pojoName);
+    return objectPojo.get();
+  }
+}

--- a/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/model/name/ComponentNames.java
+++ b/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/model/name/ComponentNames.java
@@ -6,4 +6,10 @@ public class ComponentNames {
   public static ComponentName componentName(String schemaString, String suffix) {
     return ComponentName.fromSchemaStringAndSuffix(schemaString, suffix);
   }
+
+  public static ComponentName componentName(String pojoName, String suffix, String schemaName) {
+    return new ComponentName(
+        new PojoName(Name.ofString(pojoName), suffix),
+        SchemaName.ofName(Name.ofString(schemaName)));
+  }
 }


### PR DESCRIPTION
- This fix does only supports simple schemas with nested properties. No properties of
compositions get promoted.
- One could define a schema with an all of composition, where one subschema defines
only which properties get required and
define no properties by itself. No DTO
will get generated for this subschema,
it will onyl be used to determine which
properties gets promoted.

Issue: #209