### PR TITLE
Improve all of builder stages

### DIFF
--- a/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/safebuilder/BuilderStageTest.java
+++ b/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/safebuilder/BuilderStageTest.java
@@ -5,6 +5,8 @@ import static com.github.muehmar.gradle.openapi.generator.java.model.member.Test
 import static com.github.muehmar.gradle.openapi.generator.java.model.member.TestJavaPojoMembers.requiredDouble;
 import static com.github.muehmar.gradle.openapi.generator.java.model.member.TestJavaPojoMembers.requiredEmail;
 import static com.github.muehmar.gradle.openapi.generator.java.model.member.TestJavaPojoMembers.requiredString;
+import static com.github.muehmar.gradle.openapi.generator.java.model.pojo.JavaPojos.sampleObjectPojo1;
+import static com.github.muehmar.gradle.openapi.generator.java.model.pojo.JavaPojos.sampleObjectPojo2;
 
 import au.com.origin.snapshots.Expect;
 import au.com.origin.snapshots.annotations.SnapshotName;
@@ -56,7 +58,7 @@ class BuilderStageTest {
         JavaPojos.allOfPojo(
                 JavaPojos.allNecessityAndNullabilityVariants()
                     .withRequiredAdditionalProperties(PROP_2_ADDITIONAL_PROPERTIES),
-                JavaPojos.sampleObjectPojo1())
+                sampleObjectPojo1())
             .withMembers(
                 JavaPojoMembers.fromMembers(PList.of(byteArrayMember(), optionalString())));
 
@@ -73,7 +75,7 @@ class BuilderStageTest {
   void createStages_when_allOfPojoWithOneOfAndAnyOfSubSchema_matchStages(
       SafeBuilderVariant builderVariant) {
     final JavaObjectPojo oneOfSubPojo =
-        JavaPojos.oneOfPojo(JavaPojos.sampleObjectPojo2())
+        JavaPojos.oneOfPojo(sampleObjectPojo2())
             .withMembers(JavaPojoMembers.empty().add(requiredDouble()).add(requiredEmail()));
     final JavaObjectPojo pojo =
         JavaPojos.allOfPojo(JavaPojos.allNecessityAndNullabilityVariants(), oneOfSubPojo)
@@ -89,11 +91,25 @@ class BuilderStageTest {
 
   @ParameterizedTest
   @EnumSource(SafeBuilderVariant.class)
+  @SnapshotName(("allOfPojoWithSameMemberInAllOfSubPojos"))
+  void createStages_when_allOfPojoWithSameMemberInAllOfSubPojos_matchStages(
+      SafeBuilderVariant builderVariant) {
+    final JavaObjectPojo allOfPojo = JavaPojos.allOfPojo(sampleObjectPojo1(), sampleObjectPojo2());
+    ;
+
+    final NonEmptyList<BuilderStage> stages = BuilderStage.createStages(builderVariant, allOfPojo);
+
+    expect
+        .scenario(builderVariant.name())
+        .toMatchSnapshot(stages.map(BuilderStageTest::formatStage).toPList().mkString("\n"));
+  }
+
+  @ParameterizedTest
+  @EnumSource(SafeBuilderVariant.class)
   @SnapshotName(("oneOfPojoWithMembers"))
   void createStages_when_oneOfPojoWithMembers_matchStages(SafeBuilderVariant builderVariant) {
     final JavaObjectPojo pojo =
-        JavaPojos.oneOfPojo(
-                JavaPojos.allNecessityAndNullabilityVariants(), JavaPojos.sampleObjectPojo1())
+        JavaPojos.oneOfPojo(JavaPojos.allNecessityAndNullabilityVariants(), sampleObjectPojo1())
             .withMembers(
                 JavaPojoMembers.fromMembers(PList.of(byteArrayMember(), optionalString())));
 
@@ -109,8 +125,7 @@ class BuilderStageTest {
   @SnapshotName(("anyOfPojoWithMembers"))
   void createStages_when_anyOfPojoWithMembers_matchStages(SafeBuilderVariant builderVariant) {
     final JavaObjectPojo pojo =
-        JavaPojos.anyOfPojo(
-                JavaPojos.allNecessityAndNullabilityVariants(), JavaPojos.sampleObjectPojo1())
+        JavaPojos.anyOfPojo(JavaPojos.allNecessityAndNullabilityVariants(), sampleObjectPojo1())
             .withMembers(
                 JavaPojoMembers.fromMembers(PList.of(byteArrayMember(), optionalString())));
 
@@ -127,8 +142,7 @@ class BuilderStageTest {
   void createStages_when_allOfPojoWithRequiredProperties_matchStages(
       SafeBuilderVariant builderVariant) {
     final JavaObjectPojo pojo =
-        JavaPojos.allOfPojo(
-                JavaPojos.allNecessityAndNullabilityVariants(), JavaPojos.sampleObjectPojo1())
+        JavaPojos.allOfPojo(JavaPojos.allNecessityAndNullabilityVariants(), sampleObjectPojo1())
             .withRequiredAdditionalProperties(PROP_2_ADDITIONAL_PROPERTIES);
 
     final NonEmptyList<BuilderStage> stages = BuilderStage.createStages(builderVariant, pojo);
@@ -144,8 +158,7 @@ class BuilderStageTest {
   void createStages_when_oneOfPojoWithRequiredProperties_matchStages(
       SafeBuilderVariant builderVariant) {
     final JavaObjectPojo pojo =
-        JavaPojos.oneOfPojo(
-                JavaPojos.allNecessityAndNullabilityVariants(), JavaPojos.sampleObjectPojo1())
+        JavaPojos.oneOfPojo(JavaPojos.allNecessityAndNullabilityVariants(), sampleObjectPojo1())
             .withRequiredAdditionalProperties(PROP_2_ADDITIONAL_PROPERTIES);
 
     final NonEmptyList<BuilderStage> stages = BuilderStage.createStages(builderVariant, pojo);
@@ -161,8 +174,7 @@ class BuilderStageTest {
   void createStages_when_anyOfPojoWithRequiredProperties_matchStages(
       SafeBuilderVariant builderVariant) {
     final JavaObjectPojo pojo =
-        JavaPojos.anyOfPojo(
-                JavaPojos.allNecessityAndNullabilityVariants(), JavaPojos.sampleObjectPojo1())
+        JavaPojos.anyOfPojo(JavaPojos.allNecessityAndNullabilityVariants(), sampleObjectPojo1())
             .withRequiredAdditionalProperties(PROP_2_ADDITIONAL_PROPERTIES);
 
     final NonEmptyList<BuilderStage> stages = BuilderStage.createStages(builderVariant, pojo);

--- a/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/safebuilder/__snapshots__/BuilderStageTest.snap
+++ b/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/safebuilder/__snapshots__/BuilderStageTest.snap
@@ -100,6 +100,27 @@ LastOptionalPropertyBuilderStage - OptPropertyBuilder0
 ]
 
 
+allOfPojoWithSameMemberInAllOfSubPojos[FULL]=[
+AllOfBuilderStage - FullAllOfBuilderSampleObjectPojo10 for Optional[stringVal](0), next stage FullAllOfBuilderSampleObjectPojo20, next member stage: FullAllOfBuilderSampleObjectPojo11
+AllOfBuilderStage - FullAllOfBuilderSampleObjectPojo11 for Optional[intVal](1), next stage FullAllOfBuilderSampleObjectPojo20, next member stage: FullAllOfBuilderSampleObjectPojo12
+AllOfBuilderStage - FullAllOfBuilderSampleObjectPojo12 for Optional[doubleVal](2), next stage FullAllOfBuilderSampleObjectPojo20, next member stage: FullAllOfBuilderSampleObjectPojo20
+AllOfBuilderStage - FullAllOfBuilderSampleObjectPojo20 for Optional[birthdate](0), next stage FullOptPropertyBuilder0, next member stage: FullAllOfBuilderSampleObjectPojo21
+AllOfBuilderStage - FullAllOfBuilderSampleObjectPojo21 for Optional[email](1), next stage FullOptPropertyBuilder0, next member stage: FullOptPropertyBuilder0
+LastOptionalPropertyBuilderStage - FullOptPropertyBuilder0
+]
+
+
+allOfPojoWithSameMemberInAllOfSubPojos[STANDARD]=[
+AllOfBuilderStage - AllOfBuilderSampleObjectPojo10 for Optional[stringVal](0), next stage AllOfBuilderSampleObjectPojo20, next member stage: AllOfBuilderSampleObjectPojo11
+AllOfBuilderStage - AllOfBuilderSampleObjectPojo11 for Optional[intVal](1), next stage AllOfBuilderSampleObjectPojo20, next member stage: AllOfBuilderSampleObjectPojo12
+AllOfBuilderStage - AllOfBuilderSampleObjectPojo12 for Optional[doubleVal](2), next stage AllOfBuilderSampleObjectPojo20, next member stage: AllOfBuilderSampleObjectPojo20
+AllOfBuilderStage - AllOfBuilderSampleObjectPojo20 for Optional[birthdate](0), next stage PropertyBuilder0, next member stage: AllOfBuilderSampleObjectPojo21
+AllOfBuilderStage - AllOfBuilderSampleObjectPojo21 for Optional[email](1), next stage PropertyBuilder0, next member stage: PropertyBuilder0
+LastRequiredPropertyBuilderStage - PropertyBuilder0, next stage OptPropertyBuilder0
+LastOptionalPropertyBuilderStage - OptPropertyBuilder0
+]
+
+
 allOfPojoWithSubschemaWithoutProperties[FULL]=[
 AllOfBuilderStage - FullAllOfBuilderObjectPojo10 for Optional.empty(0), next stage FullOptPropertyBuilder0, next member stage: FullOptPropertyBuilder0
 LastOptionalPropertyBuilderStage - FullOptPropertyBuilder0

--- a/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/safebuilder/allof/__snapshots__/AllOfBuilderGeneratorTest.snap
+++ b/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/safebuilder/allof/__snapshots__/AllOfBuilderGeneratorTest.snap
@@ -60,10 +60,10 @@ public static final class AllOfBuilderSampleObjectPojo20 {
   }
 
   /**
-   * stringVal
+   * Birthdate
    */
-  public AllOfBuilderSampleObjectPojo21 setStringVal(String stringVal) {
-    return new AllOfBuilderSampleObjectPojo21(builder.setStringVal(stringVal));
+  public AllOfBuilderSampleObjectPojo21 setBirthdate(LocalDate birthdate) {
+    return new AllOfBuilderSampleObjectPojo21(builder.setBirthdate(birthdate));
   }
 
   public AllOfBuilderObjectPojo10 setSampleObjectPojo2Dto(SampleObjectPojo2Dto dto) {
@@ -75,22 +75,6 @@ public static final class AllOfBuilderSampleObjectPojo21 {
   private final Builder builder;
 
   private AllOfBuilderSampleObjectPojo21(Builder builder) {
-    this.builder = builder;
-  }
-
-  /**
-   * Birthdate
-   */
-  public AllOfBuilderSampleObjectPojo22 setBirthdate(LocalDate birthdate) {
-    return new AllOfBuilderSampleObjectPojo22(builder.setBirthdate(birthdate));
-  }
-
-}
-
-public static final class AllOfBuilderSampleObjectPojo22 {
-  private final Builder builder;
-
-  private AllOfBuilderSampleObjectPojo22(Builder builder) {
     this.builder = builder;
   }
 
@@ -186,10 +170,10 @@ public static final class FullAllOfBuilderSampleObjectPojo20 {
   }
 
   /**
-   * stringVal
+   * Birthdate
    */
-  public FullAllOfBuilderSampleObjectPojo21 setStringVal(String stringVal) {
-    return new FullAllOfBuilderSampleObjectPojo21(builder.setStringVal(stringVal));
+  public FullAllOfBuilderSampleObjectPojo21 setBirthdate(LocalDate birthdate) {
+    return new FullAllOfBuilderSampleObjectPojo21(builder.setBirthdate(birthdate));
   }
 
   public FullAllOfBuilderObjectPojo10 setSampleObjectPojo2Dto(SampleObjectPojo2Dto dto) {
@@ -201,22 +185,6 @@ public static final class FullAllOfBuilderSampleObjectPojo21 {
   private final Builder builder;
 
   private FullAllOfBuilderSampleObjectPojo21(Builder builder) {
-    this.builder = builder;
-  }
-
-  /**
-   * Birthdate
-   */
-  public FullAllOfBuilderSampleObjectPojo22 setBirthdate(LocalDate birthdate) {
-    return new FullAllOfBuilderSampleObjectPojo22(builder.setBirthdate(birthdate));
-  }
-
-}
-
-public static final class FullAllOfBuilderSampleObjectPojo22 {
-  private final Builder builder;
-
-  private FullAllOfBuilderSampleObjectPojo22(Builder builder) {
     this.builder = builder;
   }
 
@@ -312,10 +280,10 @@ public static final class AllOfBuilderSampleObjectPojo20 {
   }
 
   /**
-   * stringVal
+   * Birthdate
    */
-  public AllOfBuilderSampleObjectPojo21 setStringVal(String stringVal) {
-    return new AllOfBuilderSampleObjectPojo21(builder.setStringVal(stringVal));
+  public AllOfBuilderSampleObjectPojo21 setBirthdate(LocalDate birthdate) {
+    return new AllOfBuilderSampleObjectPojo21(builder.setBirthdate(birthdate));
   }
 
   public AllOfBuilderOneOfPojo10 setSampleObjectPojo2Dto(SampleObjectPojo2Dto dto) {
@@ -327,22 +295,6 @@ public static final class AllOfBuilderSampleObjectPojo21 {
   private final Builder builder;
 
   private AllOfBuilderSampleObjectPojo21(Builder builder) {
-    this.builder = builder;
-  }
-
-  /**
-   * Birthdate
-   */
-  public AllOfBuilderSampleObjectPojo22 setBirthdate(LocalDate birthdate) {
-    return new AllOfBuilderSampleObjectPojo22(builder.setBirthdate(birthdate));
-  }
-
-}
-
-public static final class AllOfBuilderSampleObjectPojo22 {
-  private final Builder builder;
-
-  private AllOfBuilderSampleObjectPojo22(Builder builder) {
     this.builder = builder;
   }
 


### PR DESCRIPTION
- Generate only one stage for a member which is present in more
than one subschemas of the allOf
composition. The stage is generated
during the stages of the first
schema. In all subsequent schema
stages, the stage for the same
member will be omitted.

Issue: #210