### PR TITLE
Improve allOf builder stages

### DIFF
--- a/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/__snapshots__/ObjectPojoGeneratorTest.snap
+++ b/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/__snapshots__/ObjectPojoGeneratorTest.snap
@@ -314,8 +314,8 @@ public class PersonDto {
       return new FullAllOfBuilderUser0(builder.setBirthdate(birthdate));
     }
 
-    public FullAllOfBuilderUser0 setAdminDto(AdminDto dto) {
-      return new FullAllOfBuilderUser0(builder.setAdminDto(dto));
+    public FullAllOfBuilderUser setAdminDto(AdminDto dto) {
+      return new FullAllOfBuilderUser(builder.setAdminDto(dto));
     }
   }
 
@@ -331,6 +331,15 @@ public class PersonDto {
      */
     public FullPropertyBuilder0 setUsername(String username) {
       return new FullPropertyBuilder0(builder.setUsername(username));
+    }
+
+  }
+
+  public static final class FullAllOfBuilderUser {
+    private final Builder builder;
+
+    private FullAllOfBuilderUser(Builder builder) {
+      this.builder = builder;
     }
 
     public FullPropertyBuilder0 setUserDto(UserDto dto) {
@@ -406,8 +415,8 @@ public class PersonDto {
       return new AllOfBuilderUser0(builder.setBirthdate(birthdate));
     }
 
-    public AllOfBuilderUser0 setAdminDto(AdminDto dto) {
-      return new AllOfBuilderUser0(builder.setAdminDto(dto));
+    public AllOfBuilderUser setAdminDto(AdminDto dto) {
+      return new AllOfBuilderUser(builder.setAdminDto(dto));
     }
   }
 
@@ -423,6 +432,15 @@ public class PersonDto {
      */
     public PropertyBuilder0 setUsername(String username) {
       return new PropertyBuilder0(builder.setUsername(username));
+    }
+
+  }
+
+  public static final class AllOfBuilderUser {
+    private final Builder builder;
+
+    private AllOfBuilderUser(Builder builder) {
+      this.builder = builder;
     }
 
     public PropertyBuilder0 setUserDto(UserDto dto) {

--- a/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/safebuilder/__snapshots__/BuilderStageTest.snap
+++ b/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/safebuilder/__snapshots__/BuilderStageTest.snap
@@ -20,14 +20,15 @@ LastOptionalPropertyBuilderStage - OptPropertyBuilder2
 
 
 allOfPojoWithMembers[FULL]=[
-AllOfBuilderStage - FullAllOfBuilderNecessityAndNullability0 for Optional[requiredStringVal](0), next stage FullAllOfBuilderSampleObjectPojo10, next member stage: FullAllOfBuilderNecessityAndNullability1
-AllOfBuilderStage - FullAllOfBuilderNecessityAndNullability1 for Optional[requiredNullableStringVal](1), next stage FullAllOfBuilderSampleObjectPojo10, next member stage: FullAllOfBuilderNecessityAndNullability2
-AllOfBuilderStage - FullAllOfBuilderNecessityAndNullability2 for Optional[optionalStringVal](2), next stage FullAllOfBuilderSampleObjectPojo10, next member stage: FullAllOfBuilderNecessityAndNullability3
-AllOfBuilderStage - FullAllOfBuilderNecessityAndNullability3 for Optional[optionalNullableStringVal](3), next stage FullAllOfBuilderSampleObjectPojo10, next member stage: FullAllOfBuilderNecessityAndNullability4
-AllOfBuilderStage - FullAllOfBuilderNecessityAndNullability4 for Optional[Prop2](4), next stage FullAllOfBuilderSampleObjectPojo10, next member stage: FullAllOfBuilderSampleObjectPojo10
-AllOfBuilderStage - FullAllOfBuilderSampleObjectPojo10 for Optional[stringVal](0), next stage FullPropertyBuilder0, next member stage: FullAllOfBuilderSampleObjectPojo11
-AllOfBuilderStage - FullAllOfBuilderSampleObjectPojo11 for Optional[intVal](1), next stage FullPropertyBuilder0, next member stage: FullAllOfBuilderSampleObjectPojo12
-AllOfBuilderStage - FullAllOfBuilderSampleObjectPojo12 for Optional[doubleVal](2), next stage FullPropertyBuilder0, next member stage: FullPropertyBuilder0
+AllOfBuilderStage - FullAllOfBuilderNecessityAndNullability0 for requiredStringVal(0), next stage: FullAllOfBuilderNecessityAndNullability1, next pojo stage: FullAllOfBuilderSampleObjectPojo1
+AllOfBuilderStage - FullAllOfBuilderNecessityAndNullability1 for requiredNullableStringVal(1), next stage: FullAllOfBuilderNecessityAndNullability2
+AllOfBuilderStage - FullAllOfBuilderNecessityAndNullability2 for optionalStringVal(2), next stage: FullAllOfBuilderNecessityAndNullability3
+AllOfBuilderStage - FullAllOfBuilderNecessityAndNullability3 for optionalNullableStringVal(3), next stage: FullAllOfBuilderNecessityAndNullability4
+AllOfBuilderStage - FullAllOfBuilderNecessityAndNullability4 for Prop2(4), next stage: FullAllOfBuilderSampleObjectPojo10
+AllOfBuilderStage - FullAllOfBuilderSampleObjectPojo10 for stringVal(0), next stage: FullAllOfBuilderSampleObjectPojo11
+AllOfBuilderStage - FullAllOfBuilderSampleObjectPojo11 for intVal(1), next stage: FullAllOfBuilderSampleObjectPojo12
+AllOfBuilderStage - FullAllOfBuilderSampleObjectPojo12 for doubleVal(2), next stage: FullPropertyBuilder0
+AllOfBuilderStage - FullAllOfBuilderSampleObjectPojo1, next pojo stage: FullPropertyBuilder0
 RequiredPropertyBuilderStage - FullPropertyBuilder0 for data(0), next stage FullOptPropertyBuilder0
 OptionalPropertyBuilderStage - FullOptPropertyBuilder0 for optionalStringVal(0), next stage FullOptPropertyBuilder1
 LastOptionalPropertyBuilderStage - FullOptPropertyBuilder1
@@ -35,14 +36,15 @@ LastOptionalPropertyBuilderStage - FullOptPropertyBuilder1
 
 
 allOfPojoWithMembers[STANDARD]=[
-AllOfBuilderStage - AllOfBuilderNecessityAndNullability0 for Optional[requiredStringVal](0), next stage AllOfBuilderSampleObjectPojo10, next member stage: AllOfBuilderNecessityAndNullability1
-AllOfBuilderStage - AllOfBuilderNecessityAndNullability1 for Optional[requiredNullableStringVal](1), next stage AllOfBuilderSampleObjectPojo10, next member stage: AllOfBuilderNecessityAndNullability2
-AllOfBuilderStage - AllOfBuilderNecessityAndNullability2 for Optional[optionalStringVal](2), next stage AllOfBuilderSampleObjectPojo10, next member stage: AllOfBuilderNecessityAndNullability3
-AllOfBuilderStage - AllOfBuilderNecessityAndNullability3 for Optional[optionalNullableStringVal](3), next stage AllOfBuilderSampleObjectPojo10, next member stage: AllOfBuilderNecessityAndNullability4
-AllOfBuilderStage - AllOfBuilderNecessityAndNullability4 for Optional[Prop2](4), next stage AllOfBuilderSampleObjectPojo10, next member stage: AllOfBuilderSampleObjectPojo10
-AllOfBuilderStage - AllOfBuilderSampleObjectPojo10 for Optional[stringVal](0), next stage PropertyBuilder0, next member stage: AllOfBuilderSampleObjectPojo11
-AllOfBuilderStage - AllOfBuilderSampleObjectPojo11 for Optional[intVal](1), next stage PropertyBuilder0, next member stage: AllOfBuilderSampleObjectPojo12
-AllOfBuilderStage - AllOfBuilderSampleObjectPojo12 for Optional[doubleVal](2), next stage PropertyBuilder0, next member stage: PropertyBuilder0
+AllOfBuilderStage - AllOfBuilderNecessityAndNullability0 for requiredStringVal(0), next stage: AllOfBuilderNecessityAndNullability1, next pojo stage: AllOfBuilderSampleObjectPojo1
+AllOfBuilderStage - AllOfBuilderNecessityAndNullability1 for requiredNullableStringVal(1), next stage: AllOfBuilderNecessityAndNullability2
+AllOfBuilderStage - AllOfBuilderNecessityAndNullability2 for optionalStringVal(2), next stage: AllOfBuilderNecessityAndNullability3
+AllOfBuilderStage - AllOfBuilderNecessityAndNullability3 for optionalNullableStringVal(3), next stage: AllOfBuilderNecessityAndNullability4
+AllOfBuilderStage - AllOfBuilderNecessityAndNullability4 for Prop2(4), next stage: AllOfBuilderSampleObjectPojo10
+AllOfBuilderStage - AllOfBuilderSampleObjectPojo10 for stringVal(0), next stage: AllOfBuilderSampleObjectPojo11
+AllOfBuilderStage - AllOfBuilderSampleObjectPojo11 for intVal(1), next stage: AllOfBuilderSampleObjectPojo12
+AllOfBuilderStage - AllOfBuilderSampleObjectPojo12 for doubleVal(2), next stage: PropertyBuilder0
+AllOfBuilderStage - AllOfBuilderSampleObjectPojo1, next pojo stage: PropertyBuilder0
 RequiredPropertyBuilderStage - PropertyBuilder0 for data(0), next stage PropertyBuilder1
 LastRequiredPropertyBuilderStage - PropertyBuilder1, next stage OptPropertyBuilder0
 OptionalPropertyBuilderStage - OptPropertyBuilder0 for optionalStringVal(0), next stage OptPropertyBuilder1
@@ -51,22 +53,16 @@ LastOptionalPropertyBuilderStage - OptPropertyBuilder1
 
 
 allOfPojoWithOneOfSubPojo[FULL]=[
-AllOfBuilderStage - FullAllOfBuilderNecessityAndNullability0 for Optional[requiredStringVal](0), next stage FullAllOfBuilderOneOfPojo10, next member stage: FullAllOfBuilderNecessityAndNullability1
-AllOfBuilderStage - FullAllOfBuilderNecessityAndNullability1 for Optional[requiredNullableStringVal](1), next stage FullAllOfBuilderOneOfPojo10, next member stage: FullAllOfBuilderNecessityAndNullability2
-AllOfBuilderStage - FullAllOfBuilderNecessityAndNullability2 for Optional[optionalStringVal](2), next stage FullAllOfBuilderOneOfPojo10, next member stage: FullAllOfBuilderNecessityAndNullability3
-AllOfBuilderStage - FullAllOfBuilderNecessityAndNullability3 for Optional[optionalNullableStringVal](3), next stage FullAllOfBuilderOneOfPojo10, next member stage: FullAllOfBuilderOneOfPojo10
-AllOfBuilderStage - FullAllOfBuilderOneOfPojo10 for Optional.empty(0), next stage FullPropertyBuilder0, next member stage: FullPropertyBuilder0
+AllOfBuilderStage - FullAllOfBuilderNecessityAndNullability, next pojo stage: FullAllOfBuilderOneOfPojo1
+AllOfBuilderStage - FullAllOfBuilderOneOfPojo1, next pojo stage: FullPropertyBuilder0
 RequiredPropertyBuilderStage - FullPropertyBuilder0 for stringVal(0), next stage FullOptPropertyBuilder0
 LastOptionalPropertyBuilderStage - FullOptPropertyBuilder0
 ]
 
 
 allOfPojoWithOneOfSubPojo[STANDARD]=[
-AllOfBuilderStage - AllOfBuilderNecessityAndNullability0 for Optional[requiredStringVal](0), next stage AllOfBuilderOneOfPojo10, next member stage: AllOfBuilderNecessityAndNullability1
-AllOfBuilderStage - AllOfBuilderNecessityAndNullability1 for Optional[requiredNullableStringVal](1), next stage AllOfBuilderOneOfPojo10, next member stage: AllOfBuilderNecessityAndNullability2
-AllOfBuilderStage - AllOfBuilderNecessityAndNullability2 for Optional[optionalStringVal](2), next stage AllOfBuilderOneOfPojo10, next member stage: AllOfBuilderNecessityAndNullability3
-AllOfBuilderStage - AllOfBuilderNecessityAndNullability3 for Optional[optionalNullableStringVal](3), next stage AllOfBuilderOneOfPojo10, next member stage: AllOfBuilderOneOfPojo10
-AllOfBuilderStage - AllOfBuilderOneOfPojo10 for Optional.empty(0), next stage PropertyBuilder0, next member stage: PropertyBuilder0
+AllOfBuilderStage - AllOfBuilderNecessityAndNullability, next pojo stage: AllOfBuilderOneOfPojo1
+AllOfBuilderStage - AllOfBuilderOneOfPojo1, next pojo stage: PropertyBuilder0
 RequiredPropertyBuilderStage - PropertyBuilder0 for stringVal(0), next stage PropertyBuilder1
 LastRequiredPropertyBuilderStage - PropertyBuilder1, next stage OptPropertyBuilder0
 LastOptionalPropertyBuilderStage - OptPropertyBuilder0
@@ -74,26 +70,28 @@ LastOptionalPropertyBuilderStage - OptPropertyBuilder0
 
 
 allOfPojoWithRequiredProperties[FULL]=[
-AllOfBuilderStage - FullAllOfBuilderNecessityAndNullability0 for Optional[requiredStringVal](0), next stage FullAllOfBuilderSampleObjectPojo10, next member stage: FullAllOfBuilderNecessityAndNullability1
-AllOfBuilderStage - FullAllOfBuilderNecessityAndNullability1 for Optional[requiredNullableStringVal](1), next stage FullAllOfBuilderSampleObjectPojo10, next member stage: FullAllOfBuilderNecessityAndNullability2
-AllOfBuilderStage - FullAllOfBuilderNecessityAndNullability2 for Optional[optionalStringVal](2), next stage FullAllOfBuilderSampleObjectPojo10, next member stage: FullAllOfBuilderNecessityAndNullability3
-AllOfBuilderStage - FullAllOfBuilderNecessityAndNullability3 for Optional[optionalNullableStringVal](3), next stage FullAllOfBuilderSampleObjectPojo10, next member stage: FullAllOfBuilderSampleObjectPojo10
-AllOfBuilderStage - FullAllOfBuilderSampleObjectPojo10 for Optional[stringVal](0), next stage FullPropertyBuilder0, next member stage: FullAllOfBuilderSampleObjectPojo11
-AllOfBuilderStage - FullAllOfBuilderSampleObjectPojo11 for Optional[intVal](1), next stage FullPropertyBuilder0, next member stage: FullAllOfBuilderSampleObjectPojo12
-AllOfBuilderStage - FullAllOfBuilderSampleObjectPojo12 for Optional[doubleVal](2), next stage FullPropertyBuilder0, next member stage: FullPropertyBuilder0
+AllOfBuilderStage - FullAllOfBuilderNecessityAndNullability0 for requiredStringVal(0), next stage: FullAllOfBuilderNecessityAndNullability1, next pojo stage: FullAllOfBuilderSampleObjectPojo1
+AllOfBuilderStage - FullAllOfBuilderNecessityAndNullability1 for requiredNullableStringVal(1), next stage: FullAllOfBuilderNecessityAndNullability2
+AllOfBuilderStage - FullAllOfBuilderNecessityAndNullability2 for optionalStringVal(2), next stage: FullAllOfBuilderNecessityAndNullability3
+AllOfBuilderStage - FullAllOfBuilderNecessityAndNullability3 for optionalNullableStringVal(3), next stage: FullAllOfBuilderSampleObjectPojo10
+AllOfBuilderStage - FullAllOfBuilderSampleObjectPojo10 for stringVal(0), next stage: FullAllOfBuilderSampleObjectPojo11
+AllOfBuilderStage - FullAllOfBuilderSampleObjectPojo11 for intVal(1), next stage: FullAllOfBuilderSampleObjectPojo12
+AllOfBuilderStage - FullAllOfBuilderSampleObjectPojo12 for doubleVal(2), next stage: FullPropertyBuilder0
+AllOfBuilderStage - FullAllOfBuilderSampleObjectPojo1, next pojo stage: FullPropertyBuilder0
 RequiredPropertyBuilderStage - FullPropertyBuilder0 for Prop2(0), next stage FullOptPropertyBuilder0
 LastOptionalPropertyBuilderStage - FullOptPropertyBuilder0
 ]
 
 
 allOfPojoWithRequiredProperties[STANDARD]=[
-AllOfBuilderStage - AllOfBuilderNecessityAndNullability0 for Optional[requiredStringVal](0), next stage AllOfBuilderSampleObjectPojo10, next member stage: AllOfBuilderNecessityAndNullability1
-AllOfBuilderStage - AllOfBuilderNecessityAndNullability1 for Optional[requiredNullableStringVal](1), next stage AllOfBuilderSampleObjectPojo10, next member stage: AllOfBuilderNecessityAndNullability2
-AllOfBuilderStage - AllOfBuilderNecessityAndNullability2 for Optional[optionalStringVal](2), next stage AllOfBuilderSampleObjectPojo10, next member stage: AllOfBuilderNecessityAndNullability3
-AllOfBuilderStage - AllOfBuilderNecessityAndNullability3 for Optional[optionalNullableStringVal](3), next stage AllOfBuilderSampleObjectPojo10, next member stage: AllOfBuilderSampleObjectPojo10
-AllOfBuilderStage - AllOfBuilderSampleObjectPojo10 for Optional[stringVal](0), next stage PropertyBuilder0, next member stage: AllOfBuilderSampleObjectPojo11
-AllOfBuilderStage - AllOfBuilderSampleObjectPojo11 for Optional[intVal](1), next stage PropertyBuilder0, next member stage: AllOfBuilderSampleObjectPojo12
-AllOfBuilderStage - AllOfBuilderSampleObjectPojo12 for Optional[doubleVal](2), next stage PropertyBuilder0, next member stage: PropertyBuilder0
+AllOfBuilderStage - AllOfBuilderNecessityAndNullability0 for requiredStringVal(0), next stage: AllOfBuilderNecessityAndNullability1, next pojo stage: AllOfBuilderSampleObjectPojo1
+AllOfBuilderStage - AllOfBuilderNecessityAndNullability1 for requiredNullableStringVal(1), next stage: AllOfBuilderNecessityAndNullability2
+AllOfBuilderStage - AllOfBuilderNecessityAndNullability2 for optionalStringVal(2), next stage: AllOfBuilderNecessityAndNullability3
+AllOfBuilderStage - AllOfBuilderNecessityAndNullability3 for optionalNullableStringVal(3), next stage: AllOfBuilderSampleObjectPojo10
+AllOfBuilderStage - AllOfBuilderSampleObjectPojo10 for stringVal(0), next stage: AllOfBuilderSampleObjectPojo11
+AllOfBuilderStage - AllOfBuilderSampleObjectPojo11 for intVal(1), next stage: AllOfBuilderSampleObjectPojo12
+AllOfBuilderStage - AllOfBuilderSampleObjectPojo12 for doubleVal(2), next stage: PropertyBuilder0
+AllOfBuilderStage - AllOfBuilderSampleObjectPojo1, next pojo stage: PropertyBuilder0
 RequiredPropertyBuilderStage - PropertyBuilder0 for Prop2(0), next stage PropertyBuilder1
 LastRequiredPropertyBuilderStage - PropertyBuilder1, next stage OptPropertyBuilder0
 LastOptionalPropertyBuilderStage - OptPropertyBuilder0
@@ -101,34 +99,36 @@ LastOptionalPropertyBuilderStage - OptPropertyBuilder0
 
 
 allOfPojoWithSameMemberInAllOfSubPojos[FULL]=[
-AllOfBuilderStage - FullAllOfBuilderSampleObjectPojo10 for Optional[stringVal](0), next stage FullAllOfBuilderSampleObjectPojo20, next member stage: FullAllOfBuilderSampleObjectPojo11
-AllOfBuilderStage - FullAllOfBuilderSampleObjectPojo11 for Optional[intVal](1), next stage FullAllOfBuilderSampleObjectPojo20, next member stage: FullAllOfBuilderSampleObjectPojo12
-AllOfBuilderStage - FullAllOfBuilderSampleObjectPojo12 for Optional[doubleVal](2), next stage FullAllOfBuilderSampleObjectPojo20, next member stage: FullAllOfBuilderSampleObjectPojo20
-AllOfBuilderStage - FullAllOfBuilderSampleObjectPojo20 for Optional[birthdate](0), next stage FullOptPropertyBuilder0, next member stage: FullAllOfBuilderSampleObjectPojo21
-AllOfBuilderStage - FullAllOfBuilderSampleObjectPojo21 for Optional[email](1), next stage FullOptPropertyBuilder0, next member stage: FullOptPropertyBuilder0
+AllOfBuilderStage - FullAllOfBuilderSampleObjectPojo10 for stringVal(0), next stage: FullAllOfBuilderSampleObjectPojo11, next pojo stage: FullAllOfBuilderSampleObjectPojo2
+AllOfBuilderStage - FullAllOfBuilderSampleObjectPojo11 for intVal(1), next stage: FullAllOfBuilderSampleObjectPojo12
+AllOfBuilderStage - FullAllOfBuilderSampleObjectPojo12 for doubleVal(2), next stage: FullAllOfBuilderSampleObjectPojo21
+AllOfBuilderStage - FullAllOfBuilderSampleObjectPojo21 for birthdate(1), next stage: FullAllOfBuilderSampleObjectPojo22
+AllOfBuilderStage - FullAllOfBuilderSampleObjectPojo22 for email(2), next stage: FullOptPropertyBuilder0
+AllOfBuilderStage - FullAllOfBuilderSampleObjectPojo2, next pojo stage: FullOptPropertyBuilder0
 LastOptionalPropertyBuilderStage - FullOptPropertyBuilder0
 ]
 
 
 allOfPojoWithSameMemberInAllOfSubPojos[STANDARD]=[
-AllOfBuilderStage - AllOfBuilderSampleObjectPojo10 for Optional[stringVal](0), next stage AllOfBuilderSampleObjectPojo20, next member stage: AllOfBuilderSampleObjectPojo11
-AllOfBuilderStage - AllOfBuilderSampleObjectPojo11 for Optional[intVal](1), next stage AllOfBuilderSampleObjectPojo20, next member stage: AllOfBuilderSampleObjectPojo12
-AllOfBuilderStage - AllOfBuilderSampleObjectPojo12 for Optional[doubleVal](2), next stage AllOfBuilderSampleObjectPojo20, next member stage: AllOfBuilderSampleObjectPojo20
-AllOfBuilderStage - AllOfBuilderSampleObjectPojo20 for Optional[birthdate](0), next stage PropertyBuilder0, next member stage: AllOfBuilderSampleObjectPojo21
-AllOfBuilderStage - AllOfBuilderSampleObjectPojo21 for Optional[email](1), next stage PropertyBuilder0, next member stage: PropertyBuilder0
+AllOfBuilderStage - AllOfBuilderSampleObjectPojo10 for stringVal(0), next stage: AllOfBuilderSampleObjectPojo11, next pojo stage: AllOfBuilderSampleObjectPojo2
+AllOfBuilderStage - AllOfBuilderSampleObjectPojo11 for intVal(1), next stage: AllOfBuilderSampleObjectPojo12
+AllOfBuilderStage - AllOfBuilderSampleObjectPojo12 for doubleVal(2), next stage: AllOfBuilderSampleObjectPojo21
+AllOfBuilderStage - AllOfBuilderSampleObjectPojo21 for birthdate(1), next stage: AllOfBuilderSampleObjectPojo22
+AllOfBuilderStage - AllOfBuilderSampleObjectPojo22 for email(2), next stage: PropertyBuilder0
+AllOfBuilderStage - AllOfBuilderSampleObjectPojo2, next pojo stage: PropertyBuilder0
 LastRequiredPropertyBuilderStage - PropertyBuilder0, next stage OptPropertyBuilder0
 LastOptionalPropertyBuilderStage - OptPropertyBuilder0
 ]
 
 
 allOfPojoWithSubschemaWithoutProperties[FULL]=[
-AllOfBuilderStage - FullAllOfBuilderObjectPojo10 for Optional.empty(0), next stage FullOptPropertyBuilder0, next member stage: FullOptPropertyBuilder0
+AllOfBuilderStage - FullAllOfBuilderObjectPojo1, next pojo stage: FullOptPropertyBuilder0
 LastOptionalPropertyBuilderStage - FullOptPropertyBuilder0
 ]
 
 
 allOfPojoWithSubschemaWithoutProperties[STANDARD]=[
-AllOfBuilderStage - AllOfBuilderObjectPojo10 for Optional.empty(0), next stage PropertyBuilder0, next member stage: PropertyBuilder0
+AllOfBuilderStage - AllOfBuilderObjectPojo1, next pojo stage: PropertyBuilder0
 LastRequiredPropertyBuilderStage - PropertyBuilder0, next stage OptPropertyBuilder0
 LastOptionalPropertyBuilderStage - OptPropertyBuilder0
 ]
@@ -197,6 +197,39 @@ LastOptionalPropertyBuilderStage - FullOptPropertyBuilder0
 anyOfPojoWithSubschemaWithoutProperties[STANDARD]=[
 AnyOfBuilderStage - AnyOfBuilder0, type FIRST_STAGE and next stage PropertyBuilder0
 AnyOfBuilderStage - AnyOfBuilder1, type REMAINING_STAGE and next stage PropertyBuilder0
+LastRequiredPropertyBuilderStage - PropertyBuilder0, next stage OptPropertyBuilder0
+LastOptionalPropertyBuilderStage - OptPropertyBuilder0
+]
+
+
+nestedAllOfPojo[FULL]=[
+AllOfBuilderStage - FullAllOfBuilderNecessityAndNullability0 for requiredStringVal(0), next stage: FullAllOfBuilderNecessityAndNullability1, next pojo stage: FullAllOfBuilderAllOfPojo1
+AllOfBuilderStage - FullAllOfBuilderNecessityAndNullability1 for requiredNullableStringVal(1), next stage: FullAllOfBuilderNecessityAndNullability2
+AllOfBuilderStage - FullAllOfBuilderNecessityAndNullability2 for optionalStringVal(2), next stage: FullAllOfBuilderNecessityAndNullability3
+AllOfBuilderStage - FullAllOfBuilderNecessityAndNullability3 for optionalNullableStringVal(3), next stage: FullAllOfBuilderNecessityAndNullability4
+AllOfBuilderStage - FullAllOfBuilderNecessityAndNullability4 for Prop2(4), next stage: FullAllOfBuilderAllOfPojo10
+AllOfBuilderStage - FullAllOfBuilderAllOfPojo10 for stringVal(0), next stage: FullAllOfBuilderAllOfPojo11
+AllOfBuilderStage - FullAllOfBuilderAllOfPojo11 for intVal(1), next stage: FullAllOfBuilderAllOfPojo12
+AllOfBuilderStage - FullAllOfBuilderAllOfPojo12 for doubleVal(2), next stage: FullAllOfBuilderAllOfPojo14
+AllOfBuilderStage - FullAllOfBuilderAllOfPojo14 for birthdate(4), next stage: FullAllOfBuilderAllOfPojo15
+AllOfBuilderStage - FullAllOfBuilderAllOfPojo15 for email(5), next stage: FullOptPropertyBuilder0
+AllOfBuilderStage - FullAllOfBuilderAllOfPojo1, next pojo stage: FullOptPropertyBuilder0
+LastOptionalPropertyBuilderStage - FullOptPropertyBuilder0
+]
+
+
+nestedAllOfPojo[STANDARD]=[
+AllOfBuilderStage - AllOfBuilderNecessityAndNullability0 for requiredStringVal(0), next stage: AllOfBuilderNecessityAndNullability1, next pojo stage: AllOfBuilderAllOfPojo1
+AllOfBuilderStage - AllOfBuilderNecessityAndNullability1 for requiredNullableStringVal(1), next stage: AllOfBuilderNecessityAndNullability2
+AllOfBuilderStage - AllOfBuilderNecessityAndNullability2 for optionalStringVal(2), next stage: AllOfBuilderNecessityAndNullability3
+AllOfBuilderStage - AllOfBuilderNecessityAndNullability3 for optionalNullableStringVal(3), next stage: AllOfBuilderNecessityAndNullability4
+AllOfBuilderStage - AllOfBuilderNecessityAndNullability4 for Prop2(4), next stage: AllOfBuilderAllOfPojo10
+AllOfBuilderStage - AllOfBuilderAllOfPojo10 for stringVal(0), next stage: AllOfBuilderAllOfPojo11
+AllOfBuilderStage - AllOfBuilderAllOfPojo11 for intVal(1), next stage: AllOfBuilderAllOfPojo12
+AllOfBuilderStage - AllOfBuilderAllOfPojo12 for doubleVal(2), next stage: AllOfBuilderAllOfPojo14
+AllOfBuilderStage - AllOfBuilderAllOfPojo14 for birthdate(4), next stage: AllOfBuilderAllOfPojo15
+AllOfBuilderStage - AllOfBuilderAllOfPojo15 for email(5), next stage: PropertyBuilder0
+AllOfBuilderStage - AllOfBuilderAllOfPojo1, next pojo stage: PropertyBuilder0
 LastRequiredPropertyBuilderStage - PropertyBuilder0, next stage OptPropertyBuilder0
 LastOptionalPropertyBuilderStage - OptPropertyBuilder0
 ]

--- a/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/safebuilder/allof/__snapshots__/AllOfBuilderGeneratorTest.snap
+++ b/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/safebuilder/allof/__snapshots__/AllOfBuilderGeneratorTest.snap
@@ -15,8 +15,8 @@ public static final class AllOfBuilderSampleObjectPojo10 {
     return new AllOfBuilderSampleObjectPojo11(builder.setStringVal(stringVal));
   }
 
-  public AllOfBuilderSampleObjectPojo20 setSampleObjectPojo1Dto(SampleObjectPojo1Dto dto) {
-    return new AllOfBuilderSampleObjectPojo20(builder.setSampleObjectPojo1Dto(dto));
+  public AllOfBuilderSampleObjectPojo2 setSampleObjectPojo1Dto(SampleObjectPojo1Dto dto) {
+    return new AllOfBuilderSampleObjectPojo2(builder.setSampleObjectPojo1Dto(dto));
   }
 }
 
@@ -46,35 +46,32 @@ public static final class AllOfBuilderSampleObjectPojo12 {
   /**
    * doubleVal
    */
-  public AllOfBuilderSampleObjectPojo20 setDoubleVal(Double doubleVal) {
-    return new AllOfBuilderSampleObjectPojo20(builder.setDoubleVal(doubleVal));
+  public AllOfBuilderSampleObjectPojo21 setDoubleVal(Double doubleVal) {
+    return new AllOfBuilderSampleObjectPojo21(builder.setDoubleVal(doubleVal));
   }
 
-}
-
-public static final class AllOfBuilderSampleObjectPojo20 {
-  private final Builder builder;
-
-  private AllOfBuilderSampleObjectPojo20(Builder builder) {
-    this.builder = builder;
-  }
-
-  /**
-   * Birthdate
-   */
-  public AllOfBuilderSampleObjectPojo21 setBirthdate(LocalDate birthdate) {
-    return new AllOfBuilderSampleObjectPojo21(builder.setBirthdate(birthdate));
-  }
-
-  public AllOfBuilderObjectPojo10 setSampleObjectPojo2Dto(SampleObjectPojo2Dto dto) {
-    return new AllOfBuilderObjectPojo10(builder.setSampleObjectPojo2Dto(dto));
-  }
 }
 
 public static final class AllOfBuilderSampleObjectPojo21 {
   private final Builder builder;
 
   private AllOfBuilderSampleObjectPojo21(Builder builder) {
+    this.builder = builder;
+  }
+
+  /**
+   * Birthdate
+   */
+  public AllOfBuilderSampleObjectPojo22 setBirthdate(LocalDate birthdate) {
+    return new AllOfBuilderSampleObjectPojo22(builder.setBirthdate(birthdate));
+  }
+
+}
+
+public static final class AllOfBuilderSampleObjectPojo22 {
+  private final Builder builder;
+
+  private AllOfBuilderSampleObjectPojo22(Builder builder) {
     this.builder = builder;
   }
 
@@ -101,6 +98,27 @@ public static final class AllOfBuilderObjectPojo10 {
     return new PropertyBuilder0(builder.setDirection(direction));
   }
 
+}
+
+public static final class AllOfBuilderSampleObjectPojo2 {
+  private final Builder builder;
+
+  private AllOfBuilderSampleObjectPojo2(Builder builder) {
+    this.builder = builder;
+  }
+
+  public AllOfBuilderObjectPojo1 setSampleObjectPojo2Dto(SampleObjectPojo2Dto dto) {
+    return new AllOfBuilderObjectPojo1(builder.setSampleObjectPojo2Dto(dto));
+  }
+}
+
+public static final class AllOfBuilderObjectPojo1 {
+  private final Builder builder;
+
+  private AllOfBuilderObjectPojo1(Builder builder) {
+    this.builder = builder;
+  }
+
   public PropertyBuilder0 setObjectPojo1Dto(ObjectPojo1Dto dto) {
     return new PropertyBuilder0(builder.setObjectPojo1Dto(dto));
   }
@@ -125,8 +143,8 @@ public static final class FullAllOfBuilderSampleObjectPojo10 {
     return new FullAllOfBuilderSampleObjectPojo11(builder.setStringVal(stringVal));
   }
 
-  public FullAllOfBuilderSampleObjectPojo20 setSampleObjectPojo1Dto(SampleObjectPojo1Dto dto) {
-    return new FullAllOfBuilderSampleObjectPojo20(builder.setSampleObjectPojo1Dto(dto));
+  public FullAllOfBuilderSampleObjectPojo2 setSampleObjectPojo1Dto(SampleObjectPojo1Dto dto) {
+    return new FullAllOfBuilderSampleObjectPojo2(builder.setSampleObjectPojo1Dto(dto));
   }
 }
 
@@ -156,35 +174,32 @@ public static final class FullAllOfBuilderSampleObjectPojo12 {
   /**
    * doubleVal
    */
-  public FullAllOfBuilderSampleObjectPojo20 setDoubleVal(Double doubleVal) {
-    return new FullAllOfBuilderSampleObjectPojo20(builder.setDoubleVal(doubleVal));
+  public FullAllOfBuilderSampleObjectPojo21 setDoubleVal(Double doubleVal) {
+    return new FullAllOfBuilderSampleObjectPojo21(builder.setDoubleVal(doubleVal));
   }
 
-}
-
-public static final class FullAllOfBuilderSampleObjectPojo20 {
-  private final Builder builder;
-
-  private FullAllOfBuilderSampleObjectPojo20(Builder builder) {
-    this.builder = builder;
-  }
-
-  /**
-   * Birthdate
-   */
-  public FullAllOfBuilderSampleObjectPojo21 setBirthdate(LocalDate birthdate) {
-    return new FullAllOfBuilderSampleObjectPojo21(builder.setBirthdate(birthdate));
-  }
-
-  public FullAllOfBuilderObjectPojo10 setSampleObjectPojo2Dto(SampleObjectPojo2Dto dto) {
-    return new FullAllOfBuilderObjectPojo10(builder.setSampleObjectPojo2Dto(dto));
-  }
 }
 
 public static final class FullAllOfBuilderSampleObjectPojo21 {
   private final Builder builder;
 
   private FullAllOfBuilderSampleObjectPojo21(Builder builder) {
+    this.builder = builder;
+  }
+
+  /**
+   * Birthdate
+   */
+  public FullAllOfBuilderSampleObjectPojo22 setBirthdate(LocalDate birthdate) {
+    return new FullAllOfBuilderSampleObjectPojo22(builder.setBirthdate(birthdate));
+  }
+
+}
+
+public static final class FullAllOfBuilderSampleObjectPojo22 {
+  private final Builder builder;
+
+  private FullAllOfBuilderSampleObjectPojo22(Builder builder) {
     this.builder = builder;
   }
 
@@ -211,6 +226,27 @@ public static final class FullAllOfBuilderObjectPojo10 {
     return new FullOptPropertyBuilder0(builder.setDirection(direction));
   }
 
+}
+
+public static final class FullAllOfBuilderSampleObjectPojo2 {
+  private final Builder builder;
+
+  private FullAllOfBuilderSampleObjectPojo2(Builder builder) {
+    this.builder = builder;
+  }
+
+  public FullAllOfBuilderObjectPojo1 setSampleObjectPojo2Dto(SampleObjectPojo2Dto dto) {
+    return new FullAllOfBuilderObjectPojo1(builder.setSampleObjectPojo2Dto(dto));
+  }
+}
+
+public static final class FullAllOfBuilderObjectPojo1 {
+  private final Builder builder;
+
+  private FullAllOfBuilderObjectPojo1(Builder builder) {
+    this.builder = builder;
+  }
+
   public FullOptPropertyBuilder0 setObjectPojo1Dto(ObjectPojo1Dto dto) {
     return new FullOptPropertyBuilder0(builder.setObjectPojo1Dto(dto));
   }
@@ -219,98 +255,36 @@ public static final class FullAllOfBuilderObjectPojo10 {
 
 
 allOfPojoWithCompositionsInAllOfSubPojos=[
-java.time.LocalDate
-
-public static final class AllOfBuilderSampleObjectPojo10 {
+.
+.
+public static final class AllOfBuilderSampleObjectPojo1 {
   private final Builder builder;
 
-  private AllOfBuilderSampleObjectPojo10(Builder builder) {
+  private AllOfBuilderSampleObjectPojo1(Builder builder) {
     this.builder = builder;
   }
 
-  /**
-   * stringVal
-   */
-  public AllOfBuilderSampleObjectPojo11 setStringVal(String stringVal) {
-    return new AllOfBuilderSampleObjectPojo11(builder.setStringVal(stringVal));
-  }
-
-  public AllOfBuilderSampleObjectPojo20 setSampleObjectPojo1Dto(SampleObjectPojo1Dto dto) {
-    return new AllOfBuilderSampleObjectPojo20(builder.setSampleObjectPojo1Dto(dto));
+  public AllOfBuilderSampleObjectPojo2 setSampleObjectPojo1Dto(SampleObjectPojo1Dto dto) {
+    return new AllOfBuilderSampleObjectPojo2(builder.setSampleObjectPojo1Dto(dto));
   }
 }
 
-public static final class AllOfBuilderSampleObjectPojo11 {
+public static final class AllOfBuilderSampleObjectPojo2 {
   private final Builder builder;
 
-  private AllOfBuilderSampleObjectPojo11(Builder builder) {
+  private AllOfBuilderSampleObjectPojo2(Builder builder) {
     this.builder = builder;
   }
 
-  /**
-   * intVal
-   */
-  public AllOfBuilderSampleObjectPojo12 setIntVal(Integer intVal) {
-    return new AllOfBuilderSampleObjectPojo12(builder.setIntVal(intVal));
-  }
-
-}
-
-public static final class AllOfBuilderSampleObjectPojo12 {
-  private final Builder builder;
-
-  private AllOfBuilderSampleObjectPojo12(Builder builder) {
-    this.builder = builder;
-  }
-
-  /**
-   * doubleVal
-   */
-  public AllOfBuilderSampleObjectPojo20 setDoubleVal(Double doubleVal) {
-    return new AllOfBuilderSampleObjectPojo20(builder.setDoubleVal(doubleVal));
-  }
-
-}
-
-public static final class AllOfBuilderSampleObjectPojo20 {
-  private final Builder builder;
-
-  private AllOfBuilderSampleObjectPojo20(Builder builder) {
-    this.builder = builder;
-  }
-
-  /**
-   * Birthdate
-   */
-  public AllOfBuilderSampleObjectPojo21 setBirthdate(LocalDate birthdate) {
-    return new AllOfBuilderSampleObjectPojo21(builder.setBirthdate(birthdate));
-  }
-
-  public AllOfBuilderOneOfPojo10 setSampleObjectPojo2Dto(SampleObjectPojo2Dto dto) {
-    return new AllOfBuilderOneOfPojo10(builder.setSampleObjectPojo2Dto(dto));
+  public AllOfBuilderOneOfPojo1 setSampleObjectPojo2Dto(SampleObjectPojo2Dto dto) {
+    return new AllOfBuilderOneOfPojo1(builder.setSampleObjectPojo2Dto(dto));
   }
 }
 
-public static final class AllOfBuilderSampleObjectPojo21 {
+public static final class AllOfBuilderOneOfPojo1 {
   private final Builder builder;
 
-  private AllOfBuilderSampleObjectPojo21(Builder builder) {
-    this.builder = builder;
-  }
-
-  /**
-   * email
-   */
-  public AllOfBuilderOneOfPojo10 setEmail(String email) {
-    return new AllOfBuilderOneOfPojo10(builder.setEmail(email));
-  }
-
-}
-
-public static final class AllOfBuilderOneOfPojo10 {
-  private final Builder builder;
-
-  private AllOfBuilderOneOfPojo10(Builder builder) {
+  private AllOfBuilderOneOfPojo1(Builder builder) {
     this.builder = builder;
   }
 

--- a/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/model/pojo/JavaPojos.java
+++ b/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/model/pojo/JavaPojos.java
@@ -110,8 +110,8 @@ public class JavaPojos {
 
   public static JavaObjectPojo allOfPojo(JavaAllOfComposition javaAllOfComposition) {
     return JavaObjectPojoBuilder.create()
-        .name(JavaPojoNames.fromNameAndSuffix("OneOfPojo1", "Dto"))
-        .schemaName(SchemaName.ofString("OneOfPojo1"))
+        .name(JavaPojoNames.fromNameAndSuffix("AllOfPojo1", "Dto"))
+        .schemaName(SchemaName.ofString("AllOfPojo1"))
         .description("")
         .members(JavaPojoMembers.empty())
         .type(PojoType.DEFAULT)


### PR DESCRIPTION
- The user can either use only members or only DTO's
to populate the allOf part.
Stages for subsequent members
with the same name are omitted.
- The builder supports now also nested allOf compositions,
i.e. provide member setters
for the nested allOf schemas.

Issue: #227
Issue: #244