### PR TITLE
Handle null as additionalArguments

### DIFF
--- a/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/java/generator/shared/misc/PojoConstructorGenerator.java
+++ b/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/java/generator/shared/misc/PojoConstructorGenerator.java
@@ -87,7 +87,7 @@ public class PojoConstructorGenerator {
         .map(
             props ->
                 String.format(
-                    "this.%s = Collections.unmodifiableMap(%s);",
+                    "this.%s = %s == null ? Collections.emptyMap() : Collections.unmodifiableMap(%2$s);",
                     additionalPropertiesName(), additionalPropertiesName()));
   }
 

--- a/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/__snapshots__/JavaPojoGeneratorTest.snap
+++ b/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/__snapshots__/JavaPojoGeneratorTest.snap
@@ -194,7 +194,7 @@ public class SampleObjectPojo1Dto {
     this.stringVal = stringVal;
     this.intVal = intVal;
     this.doubleVal = doubleVal;
-    this.additionalProperties = Collections.unmodifiableMap(additionalProperties);
+    this.additionalProperties = additionalProperties == null ? Collections.emptyMap() : Collections.unmodifiableMap(additionalProperties);
   }
 
   /**

--- a/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/__snapshots__/ObjectPojoGeneratorTest.snap
+++ b/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/__snapshots__/ObjectPojoGeneratorTest.snap
@@ -40,7 +40,7 @@ public class PersonDto {
     this.requiredStringVal = requiredStringVal;
     this.birthdate = birthdate;
     this.username = username;
-    this.additionalProperties = Collections.unmodifiableMap(additionalProperties);
+    this.additionalProperties = additionalProperties == null ? Collections.emptyMap() : Collections.unmodifiableMap(additionalProperties);
   }
 
   /**
@@ -594,7 +594,7 @@ public class PersonDto {
     this.requiredStringVal = requiredStringVal;
     this.birthdate = birthdate;
     this.username = username;
-    this.additionalProperties = Collections.unmodifiableMap(additionalProperties);
+    this.additionalProperties = additionalProperties == null ? Collections.emptyMap() : Collections.unmodifiableMap(additionalProperties);
   }
 
   /**
@@ -1202,7 +1202,7 @@ public class ObjectPojo1Dto {
   ObjectPojo1Dto(
       Map<String, Object> additionalProperties
     ) {
-    this.additionalProperties = Collections.unmodifiableMap(additionalProperties);
+    this.additionalProperties = additionalProperties == null ? Collections.emptyMap() : Collections.unmodifiableMap(additionalProperties);
   }
 
   public static ObjectPojo1Dto fromProperties(Map<String, Object> properties) {
@@ -1480,7 +1480,7 @@ public class UserDto {
     this.isMultipleOfValueNotNull = isMultipleOfValueNotNull;
     this.anotherPojo = anotherPojo;
     this.isAnotherPojoNotNull = isAnotherPojoNotNull;
-    this.additionalProperties = Collections.unmodifiableMap(additionalProperties);
+    this.additionalProperties = additionalProperties == null ? Collections.emptyMap() : Collections.unmodifiableMap(additionalProperties);
   }
 
   /**
@@ -2218,7 +2218,7 @@ public class UserDto {
     this.isMultipleOfValueNotNull = isMultipleOfValueNotNull;
     this.anotherPojo = anotherPojo;
     this.isAnotherPojoNotNull = isAnotherPojoNotNull;
-    this.additionalProperties = Collections.unmodifiableMap(additionalProperties);
+    this.additionalProperties = additionalProperties == null ? Collections.emptyMap() : Collections.unmodifiableMap(additionalProperties);
   }
 
   /**
@@ -2916,7 +2916,7 @@ public class UserDto {
     this.name = name;
     this.language = language;
     this.isLanguageNotNull = isLanguageNotNull;
-    this.additionalProperties = Collections.unmodifiableMap(additionalProperties);
+    this.additionalProperties = additionalProperties == null ? Collections.emptyMap() : Collections.unmodifiableMap(additionalProperties);
   }
 
   /**
@@ -3463,7 +3463,7 @@ public class Illegal_IdentifierDto {
     this.isSwitchNull = isSwitchNull;
     this.point_ = point_;
     this.isPoint_Null = isPoint_Null;
-    this.additionalProperties = Collections.unmodifiableMap(additionalProperties);
+    this.additionalProperties = additionalProperties == null ? Collections.emptyMap() : Collections.unmodifiableMap(additionalProperties);
   }
 
   /**
@@ -3949,7 +3949,7 @@ public class ObjectPojo1Dto {
   ObjectPojo1Dto(
       Map<String, Object> additionalProperties
     ) {
-    this.additionalProperties = Collections.unmodifiableMap(additionalProperties);
+    this.additionalProperties = additionalProperties == null ? Collections.emptyMap() : Collections.unmodifiableMap(additionalProperties);
   }
 
   /**
@@ -4268,7 +4268,7 @@ public class ObjectPojo1Dto {
   ObjectPojo1Dto(
       Map<String, Object> additionalProperties
     ) {
-    this.additionalProperties = Collections.unmodifiableMap(additionalProperties);
+    this.additionalProperties = additionalProperties == null ? Collections.emptyMap() : Collections.unmodifiableMap(additionalProperties);
   }
 
   public static ObjectPojo1Dto fromProperties(Map<String, Integer> properties) {
@@ -4557,7 +4557,7 @@ public class UserDto {
     this.name = name;
     this.language = language;
     this.isLanguageNotNull = isLanguageNotNull;
-    this.additionalProperties = Collections.unmodifiableMap(additionalProperties);
+    this.additionalProperties = additionalProperties == null ? Collections.emptyMap() : Collections.unmodifiableMap(additionalProperties);
   }
 
   /**
@@ -4902,7 +4902,7 @@ public class UserDto {
     this.name = name;
     this.language = language;
     this.isLanguageNotNull = isLanguageNotNull;
-    this.additionalProperties = Collections.unmodifiableMap(additionalProperties);
+    this.additionalProperties = additionalProperties == null ? Collections.emptyMap() : Collections.unmodifiableMap(additionalProperties);
   }
 
   /**
@@ -5270,7 +5270,7 @@ public class NecessityAndNullabilityDto {
     this.isOptionalListWithNullableItemsNotNull = isOptionalListWithNullableItemsNotNull;
     this.optionalNullableListWithNullableItems = optionalNullableListWithNullableItems;
     this.isOptionalNullableListWithNullableItemsNull = isOptionalNullableListWithNullableItemsNull;
-    this.additionalProperties = Collections.unmodifiableMap(additionalProperties);
+    this.additionalProperties = additionalProperties == null ? Collections.emptyMap() : Collections.unmodifiableMap(additionalProperties);
   }
 
   /**
@@ -6689,7 +6689,7 @@ public class ObjectPojo1Dto {
   ObjectPojo1Dto(
       Map<String, Object> additionalProperties
     ) {
-    this.additionalProperties = Collections.unmodifiableMap(additionalProperties);
+    this.additionalProperties = additionalProperties == null ? Collections.emptyMap() : Collections.unmodifiableMap(additionalProperties);
   }
 
   /**
@@ -6861,7 +6861,7 @@ public class ObjectPojo1Dto {
   ObjectPojo1Dto(
       Map<String, Object> additionalProperties
     ) {
-    this.additionalProperties = Collections.unmodifiableMap(additionalProperties);
+    this.additionalProperties = additionalProperties == null ? Collections.emptyMap() : Collections.unmodifiableMap(additionalProperties);
   }
 
   public static ObjectPojo1Dto fromProperties(Map<String, HelloDto> properties) {
@@ -7133,7 +7133,7 @@ public class ObjectPojo1Dto {
   ObjectPojo1Dto(
       Map<String, Object> additionalProperties
     ) {
-    this.additionalProperties = Collections.unmodifiableMap(additionalProperties);
+    this.additionalProperties = additionalProperties == null ? Collections.emptyMap() : Collections.unmodifiableMap(additionalProperties);
   }
 
   public static ObjectPojo1Dto fromProperties(Map<String, HelloDto> properties) {
@@ -7400,7 +7400,7 @@ public class ObjectPojo1Dto {
   ObjectPojo1Dto(
       Map<String, Object> additionalProperties
     ) {
-    this.additionalProperties = Collections.unmodifiableMap(additionalProperties);
+    this.additionalProperties = additionalProperties == null ? Collections.emptyMap() : Collections.unmodifiableMap(additionalProperties);
   }
 
   public static ObjectPojo1Dto fromProperties(Map<String, HelloDto> properties) {
@@ -7674,7 +7674,7 @@ public class ObjectPojo1Dto {
       Map<String, Object> additionalProperties
     ) {
     this.listVal = listVal;
-    this.additionalProperties = Collections.unmodifiableMap(additionalProperties);
+    this.additionalProperties = additionalProperties == null ? Collections.emptyMap() : Collections.unmodifiableMap(additionalProperties);
   }
 
   /**
@@ -8016,7 +8016,7 @@ public class ObjectPojo1Dto {
       Map<String, Object> additionalProperties
     ) {
     this.mapVal = mapVal;
-    this.additionalProperties = Collections.unmodifiableMap(additionalProperties);
+    this.additionalProperties = additionalProperties == null ? Collections.emptyMap() : Collections.unmodifiableMap(additionalProperties);
   }
 
   /**
@@ -8368,7 +8368,7 @@ public class PersonDto {
     this.requiredStringVal = requiredStringVal;
     this.birthdate = birthdate;
     this.username = username;
-    this.additionalProperties = Collections.unmodifiableMap(additionalProperties);
+    this.additionalProperties = additionalProperties == null ? Collections.emptyMap() : Collections.unmodifiableMap(additionalProperties);
   }
 
   /**
@@ -8959,7 +8959,7 @@ public class UserDto {
     ) {
     this.language = language;
     this.isLanguageNotNull = isLanguageNotNull;
-    this.additionalProperties = Collections.unmodifiableMap(additionalProperties);
+    this.additionalProperties = additionalProperties == null ? Collections.emptyMap() : Collections.unmodifiableMap(additionalProperties);
   }
 
   /**
@@ -9250,7 +9250,7 @@ public class UserDto {
     ) {
     this.language = language;
     this.isLanguageNotNull = isLanguageNotNull;
-    this.additionalProperties = Collections.unmodifiableMap(additionalProperties);
+    this.additionalProperties = additionalProperties == null ? Collections.emptyMap() : Collections.unmodifiableMap(additionalProperties);
   }
 
   /**
@@ -9557,7 +9557,7 @@ public class ObjectPojo1Dto {
     this.email = email;
     this.birthdate = birthdate;
     this.isBirthdateNotNull = isBirthdateNotNull;
-    this.additionalProperties = Collections.unmodifiableMap(additionalProperties);
+    this.additionalProperties = additionalProperties == null ? Collections.emptyMap() : Collections.unmodifiableMap(additionalProperties);
   }
 
   /**

--- a/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/shared/misc/__snapshots__/PojoConstructorGeneratorTest.snap
+++ b/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/shared/misc/__snapshots__/PojoConstructorGeneratorTest.snap
@@ -20,7 +20,7 @@ public Illegal_IdentifierDto(
   this.isSwitchNull = isSwitchNull;
   this.point_ = point_;
   this.isPoint_Null = isPoint_Null;
-  this.additionalProperties = Collections.unmodifiableMap(additionalProperties);
+  this.additionalProperties = additionalProperties == null ? Collections.emptyMap() : Collections.unmodifiableMap(additionalProperties);
 }
 ]
 
@@ -57,7 +57,7 @@ public NecessityAndNullabilityDto(
   this.isOptionalListWithNullableItemsNotNull = isOptionalListWithNullableItemsNotNull;
   this.optionalNullableListWithNullableItems = optionalNullableListWithNullableItems;
   this.isOptionalNullableListWithNullableItemsNull = isOptionalNullableListWithNullableItemsNull;
-  this.additionalProperties = Collections.unmodifiableMap(additionalProperties);
+  this.additionalProperties = additionalProperties == null ? Collections.emptyMap() : Collections.unmodifiableMap(additionalProperties);
 }
 ]
 
@@ -94,6 +94,6 @@ public NecessityAndNullabilityDto(
   this.isOptionalListWithNullableItemsNotNull = isOptionalListWithNullableItemsNotNull;
   this.optionalNullableListWithNullableItems = optionalNullableListWithNullableItems;
   this.isOptionalNullableListWithNullableItemsNull = isOptionalNullableListWithNullableItemsNull;
-  this.additionalProperties = Collections.unmodifiableMap(additionalProperties);
+  this.additionalProperties = additionalProperties == null ? Collections.emptyMap() : Collections.unmodifiableMap(additionalProperties);
 }
 ]


### PR DESCRIPTION
In a spring application we have a request body something like this:

```yaml
someConfiguration:
  type: "object"
  properties:
    subType:
      type: "string"
    parameters:
      type: "object"
      additionalProperties:
        type: "string"
```

This generates the code flawlessly, but when trying to use it in the controller we get a JSON parse error, because the `additionalProperties` in the constructor of the `SomeConfiguration` class is `null` and `Collections.unmodifiableMap` doesn't accept `null`.

As a simple workaround I've updated the generated code to use an empty Map if `additionalProperties` is `null`.