### PR TITLE
Fix jackson 3 deprecation warning

### DIFF
--- a/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/java/generator/shared/jackson/JacksonZonedDateTimeDeserializerGenerator.java
+++ b/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/java/generator/shared/jackson/JacksonZonedDateTimeDeserializerGenerator.java
@@ -76,7 +76,7 @@ public class JacksonZonedDateTimeDeserializerGenerator {
               .methodName("deserialize")
               .arguments(deserializeMethodArguments())
               .throwsExceptions(d -> exceptions)
-              .content(deserializeMethodContent())
+              .content(deserializeMethodContent(settings))
               .build();
 
       return AnnotationGenerator.<Void, PojoSettings>override()
@@ -90,8 +90,10 @@ public class JacksonZonedDateTimeDeserializerGenerator {
         PList.of(new Argument("JsonParser", "p"), new Argument("DeserializationContext", "ctxt"));
   }
 
-  private static Generator<Void, PojoSettings> deserializeMethodContent() {
-    return Generator.constant("return ZonedDateTime.parse(p.getText().trim());");
+  private static Generator<Void, PojoSettings> deserializeMethodContent(PojoSettings settings) {
+    final String extractor =
+        settings.getJsonSupport() == JsonSupport.JACKSON_2 ? "p.getText()" : "p.getString()";
+    return Generator.constant(String.format("return ZonedDateTime.parse(%s.trim());", extractor));
   }
 
   private static Generator<Void, PojoSettings> classEnd() {

--- a/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/shared/jackson/__snapshots__/JacksonZonedDateTimeDeserializerGeneratorTest.snap
+++ b/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/shared/jackson/__snapshots__/JacksonZonedDateTimeDeserializerGeneratorTest.snap
@@ -29,7 +29,7 @@ public class ZonedDateTimeDeserializer extends ValueDeserializer<ZonedDateTime> 
 
   @Override
   public ZonedDateTime deserialize(JsonParser p, DeserializationContext ctxt) {
-    return ZonedDateTime.parse(p.getText().trim());
+    return ZonedDateTime.parse(p.getString().trim());
   }
 }
 ]


### PR DESCRIPTION
As per [JSTEP-6](https://github.com/FasterXML/jackson-future-ideas/wiki/JSTEP-6), `getText()` is being replaced by `getString()`.