### PR TITLE
fix: guard against NPE in uniqueItems validation for absent optional arrays (#374)

### DIFF
--- a/doc/130_change_log.md
+++ b/doc/130_change_log.md
@@ -1,5 +1,8 @@
 ## Change Log
 
+* next
+    * [#374](https://github.com/muehmar/gradle-openapi-schema/issues/374) - Fix NPE in `uniqueItems` validation for
+      absent optional arrays
 * 4.0.1
     * [#372](https://github.com/muehmar/gradle-openapi-schema/issues/372) - Fix Jackson 3 deprecation warnings
 * 4.0.0

--- a/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/java/generator/shared/validation/UniqueItemsValidationMethodGenerator.java
+++ b/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/java/generator/shared/validation/UniqueItemsValidationMethodGenerator.java
@@ -25,8 +25,8 @@ public class UniqueItemsValidationMethodGenerator {
             .content(
                 member ->
                     String.format(
-                        "return new HashSet<>(%s).size() == %s.size();",
-                        member.getName(), member.getName()))
+                        "return %s == null || new HashSet<>(%s).size() == %s.size();",
+                        member.getName(), member.getName(), member.getName()))
             .build();
     return ValidationAnnotationGenerator.<JavaPojoMember>assertTrue(
             member -> String.format("%s does not contain unique items", member.getName()))

--- a/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/array/__snapshots__/ArrayPojoGeneratorTest.snap
+++ b/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/array/__snapshots__/ArrayPojoGeneratorTest.snap
@@ -86,7 +86,7 @@ public class PosologyDto {
 
   @AssertTrue(message = "items does not contain unique items")
   private boolean hasItemsUniqueItems() {
-    return new HashSet<>(items).size() == items.size();
+    return items == null || new HashSet<>(items).size() == items.size();
   }
 
   boolean isValid() {

--- a/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/__snapshots__/ObjectPojoGeneratorTest.snap
+++ b/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/__snapshots__/ObjectPojoGeneratorTest.snap
@@ -11329,7 +11329,7 @@ public class ObjectPojo1Dto {
 
   @AssertTrue(message = "listVal does not contain unique items")
   private boolean hasListValUniqueItems() {
-    return new HashSet<>(listVal).size() == listVal.size();
+    return listVal == null || new HashSet<>(listVal).size() == listVal.size();
   }
 
   @Override

--- a/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/shared/validation/__snapshots__/UniqueItemsValidationMethodGeneratorTest.snap
+++ b/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/shared/validation/__snapshots__/UniqueItemsValidationMethodGeneratorTest.snap
@@ -4,7 +4,7 @@ javax.validation.constraints.AssertTrue
 
 @AssertTrue(message = "listVal does not contain unique items")
 private boolean hasListValUniqueItems() {
-  return new HashSet<>(listVal).size() == listVal.size();
+  return listVal == null || new HashSet<>(listVal).size() == listVal.size();
 }
 ]
 
@@ -13,6 +13,6 @@ validationDisabled=[
 java.util.HashSet
 
 private boolean hasListValUniqueItems() {
-  return new HashSet<>(listVal).size() == listVal.size();
+  return listVal == null || new HashSet<>(listVal).size() == listVal.size();
 }
 ]


### PR DESCRIPTION
## Summary

Fixes #374.

The generated `@AssertTrue` uniqueItems validation method called `new HashSet<>(field)` without a null guard, throwing an NPE (wrapped as a `ValidationException` by bean validation) when an optional array with `uniqueItems: true` was absent.

The method now returns `true` for `null` values, matching the existing convention where null-ness is enforced separately by `@NotNull`.

## Changes

- `UniqueItemsValidationMethodGenerator` — add a null guard before constructing the `HashSet`.
- Updated affected snapshots (`ArrayPojoGeneratorTest`, `ObjectPojoGeneratorTest`, `UniqueItemsValidationMethodGeneratorTest`).
- Changelog entry.

## Note

This PR contains **only** the generator fix so it can be merged and released. The end-to-end example reproduction test (`Issue374Test`) is intentionally left out — it exercises the *released* plugin and would stay red until this fix ships. It will be added in a follow-up once a release including this fix is published.
