### PR TITLE
docs: fix stale option names, wrong samples and dead links (#397)

### DIFF
--- a/doc/010_configuration.md
+++ b/doc/010_configuration.md
@@ -167,7 +167,7 @@ specification if necessary.
 | sourceSet                 | &check;               | String                       | main                                                   | Source set to which the generated classes should be added.                                                                                                                                                                                                                           |
 | inputSpec                 | &cross;               | String                       |                                                        | The OpenApi 3.x specification location.                                                                                                                                                                                                                                              |
 | outputDir                 | &check;               | String / Provider[Directory] | project.layout.buildDirectory.dir("generated/openapi") | The location in which the generated sources should be stored. Can either be set as String or as Provider[Directory], which is the result of calling `project.layout.buildDirectory.dir("directory/inside/the/build/directory")`.                                                     |
-| resolveInputSpecs         | &cross;               | boolean                      | true                                                   | Input specifications are resolved for task input calculation for gradle. This requires parsing the specification to identify remote specifications. This can be disabled if needed, see [Incremental build and remote specifications](#incremental-build-and-remote-specifications). |
+| resolveInputSpecs         | &cross;               | boolean                      | true                                                   | Input specifications are resolved for task input calculation for gradle. This requires parsing the specification to identify remote specifications. This can be disabled if needed, see [Incremental build and remote specifications](100_incremental_build.md). |
 | packageName               | &cross;               | String                       | \${project.group}.\${project.name}.api.model           | Name of the package for the generated classes.                                                                                                                                                                                                                                       |
 | suffix                    | &check;               | String                       |                                                        | Suffix which gets appended to each generated class. The classes are unchanged if no suffix is provided.                                                                                                                                                                              |
 | jsonSupport               | &check;               | String                       | none                                                   | Used json support library. Possible values are `jackson-2`, `jackson-3` or `none`.                                                                                                                                                                                                   |
@@ -182,7 +182,7 @@ specification if necessary.
 | constantSchemaNameMapping | &check;               | DSL                          | -                                                      | See [Schema Name Mappings](#schema-name-mappings)                                                                                                                                                                                                                                    |
 | enumDescriptionExtraction | &check;               | DSL                          | -                                                      | See [Enum description extraction](#enum-description-extraction)                                                                                                                                                                                                                      |
 | getterSuffixes            | &check;               | DSL                          | -                                                      | See [Getter suffixes](#getter-suffixes)                                                                                                                                                                                                                                              |
-| validation                | &check;               | DSL                          | -                                                      | See [Validation](#validation-methods)                                                                                                                                                                                                                                                |
+| validation                | &check;               | DSL                          | -                                                      | See [Validation](#validation)                                                                                                                                                                                                                                                        |
 | warnings                  | &check;               | DSL                          | -                                                      | See [Warnings](#warnings)                                                                                                                                                                                                                                                            |
 
 The plugin creates for each schema a task named `generate{NAME}Model` where `{NAME}` is replaced by the used name for
@@ -243,7 +243,7 @@ validationMethods {
 | modifier             | String    | private | Modifier for validation methods. Can be one of `public`, `protected`, `package-private` or `private` |
 | deprecatedAnnotation | boolean   | false   | Determines if the validation methods should be annotated with deprecated.                            |
 
-See the Spring-Example ([build.gradle](spring-example/build.gradle)) which makes use of this configuration.
+See the SpringBoot example ([build.gradle](../springboot3-example/build.gradle)) which makes use of this configuration.
 
 ### Class Mappings
 
@@ -388,7 +388,7 @@ enumDescriptionExtraction {
 
 ### Getter suffixes
 
-This generator differentiates between 4 different properties (see chapter [Nullability](#Nullability)):
+This generator differentiates between 4 different properties (see chapter [Nullability](050_nullability.md)):
 
 * Required
 * Required and nullable
@@ -422,7 +422,7 @@ warnings {
     disableWarnings = false
     failOnWarnings = true
     failOnUnsupportedValidation = true
-    failOnMissingConversion = true
+    failOnMissingMappingConversion = true
 }
 ```
 
@@ -431,4 +431,4 @@ warnings {
 | disableWarnings             | boolean   | false                     | Disables the generation of the warnings, i.e. emits no warnings in the gradle output                             |
 | failOnWarnings              | boolean   | false                     | Global setting to fail on warnings. Will be used as default for every warning type if not configured explicitly. |
 | failOnUnsupportedValidation | boolean   | value of `failOnWarnings` | Fail on unsupported validations. Uses `failOnWarnings` if omitted.                                               |
-| failOnMissingConversion     | boolean   | value of `failOnWarnings` | Fail on missing conversions in class mappings or format type mappings. Uses `failOnWarnings` if omitted.         |
+| failOnMissingMappingConversion | boolean | value of `failOnWarnings` | Fail on missing conversions in class mappings or format type mappings. Uses `failOnWarnings` if omitted.         |

--- a/doc/030_warnings.md
+++ b/doc/030_warnings.md
@@ -5,11 +5,11 @@ warnings can also be turned off completely if necessary via configuration of the
 
 The plugin can also be configured to let the generation fail in case warnings occurred (similar to the -Werror flag for
 the Java compiler). This can be done globally for every warning or selective for any warning type, see the
-[Configuration](#configuration) section.
+[Configuration](010_configuration.md#warnings) section.
 
 The plugin generates the following warnings:
 
 | Type                       | Description                                                                                                                                                                                           |
 |----------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | UNSUPPORTED_VALIDATION     | Mappings can be defined without conversions. For custom types without conversion, no validation annotations will be generated which will produce this warning.                                        |
-| MISSING_MAPPING_CONVERSION | Mappings without conversion may lead to serialisation or validations issues (see [asd](010_configuration.md#conversions-for-mappings). This warning is generated for each mapping without conversion. |
+| MISSING_MAPPING_CONVERSION | Mappings without conversion may lead to serialisation or validations issues (see [Conversions for mappings](010_configuration.md#conversions-for-mappings)). This warning is generated for each mapping without conversion. |

--- a/doc/040_compositions.md
+++ b/doc/040_compositions.md
@@ -137,8 +137,8 @@ public AdminAndOrUserAnyOfContainerDto merge(AdminAndOrUserAnyOfContainerDto oth
 This can be used in the staged builder to create an instance of the DTO:
 
 ```java
-  private AdminOrUserDto createDto(UserDefinedInput input) {
-    return AdminOrUserDto.fullAdminOrUserBuilder()
+  private AdminAndOrUserDto createDto(UserDefinedInput input) {
+    return AdminAndOrUserDto.fullAdminAndOrUserDtoBuilder()
             .setAnyOfContainer(createComposition(input))
             .build();
 }
@@ -171,12 +171,14 @@ private AdminAndOrUserAnyOfContainerDto createComposition(UserDefinedInput input
 
 #### Decomposing `oneOf` or `anyOf` with discriminator
 
-Two fold-methods exists to decompose a `oneOf` DTO or an `anyof` DTO with discriminator:
+Two fold-methods exists to decompose a `oneOf` DTO or an `anyOf` DTO with discriminator. The methods are named
+`foldOneOf` for `oneOf` compositions and `foldAnyOf` for `anyOf` compositions with discriminator (shown below for a
+`oneOf` composition):
 
 ```java
-public <T> T fold(Function<AdminDto, T> onAdminDto, Function<UserDto, T> onUserDto);
+public <T> T foldOneOf(Function<AdminDto, T> onAdminDto, Function<UserDto, T> onUserDto);
 
-public <T> T fold(Function<AdminDto, T> onAdminDto, Function<UserDto, T> onUserDto, Supplier<T> onInvalid);
+public <T> T foldOneOf(Function<AdminDto, T> onAdminDto, Function<UserDto, T> onUserDto, Supplier<T> onInvalid);
 ```
 
 Both method accepts mapping functions for each schema, in the example case one function for the `AdminDto` and one
@@ -196,7 +198,7 @@ decomposition.
 There is a single fold method can be used to decompose an `anyOf` DTO:
 
 ```java
-  public <T> List<T> fold(Function<AdminDto, T> onAdminDto, Function<UserDto, T> onUserDto);
+  public <T> List<T> foldAnyOf(Function<AdminDto, T> onAdminDto, Function<UserDto, T> onUserDto);
 ```
 
 This method is similar to the fold method of the `oneOf` composition or `anyOf` composition with discriminator only that

--- a/doc/070_validation.md
+++ b/doc/070_validation.md
@@ -1,7 +1,7 @@
 ## Validation
 
-The generation of annotations for validation can be enabled by setting `enableValidation` to `true`. It requires at
-least version 2.0 of the java/jakarta validation api as dependency. It supports object graph validation via the `@Valid`
+The generation of annotations for validation can be enabled by setting `enabled` to `true` in the `validation` block
+(`validation { enabled = true }`). It requires at least version 2.0 of the java/jakarta validation api as dependency. It supports object graph validation via the `@Valid`
 annotation.
 
 | Validation API          | Supported versions |
@@ -55,12 +55,12 @@ no additional properties are allowed via `additionalProperties = false`). This m
 considered as valid but it will result in an invalid object as the required properties of two schemas are present.
 
 ### Examples
-* [OpenAPI spec](example/src/main/resources/openapi-validation.yml)
-* [Directory with Tests](example/src/test/java/com/github/muehmar/gradle/openapi/validation)
+* [OpenAPI spec](../example/src/main/resources/openapi-validation.yml)
+* [Directory with Tests](../example/src/test/java/com/github/muehmar/gradle/openapi/validation)
 
 Samples with Tests for compositions can be found here:
-* [OneOf Validation](example/src/test/java/com/github/muehmar/gradle/openapi/oneof/TestValidation.java)
-* [AnyOf Validation](example/src/test/java/com/github/muehmar/gradle/openapi/anyof/TestValidation.java)
+* [OneOf Validation](../example/src/test/java/com/github/muehmar/gradle/openapi/oneof/ValidationTest.java)
+* [AnyOf Validation](../example/src/test/java/com/github/muehmar/gradle/openapi/anyof/ValidationTest.java)
 
 ## Keywords `readOnly` and `writeOnly`
 These keywords for properties are supported. If used, three different DTO's for the same schema are generated:

--- a/doc/091_xml_support.md
+++ b/doc/091_xml_support.md
@@ -160,11 +160,11 @@ components:
 ```xml
 
 <Container>
-    <book>
+    <books>
         <books>one</books>
         <books>two</books>
         <books>three</books>
-    </book>
+    </books>
 </Container>
 ```
 

--- a/doc/110_limitations.md
+++ b/doc/110_limitations.md
@@ -8,4 +8,6 @@
   case ([Issue 133](https://github.com/muehmar/gradle-openapi-schema/issues/133)).
 * Only object types are supported with compositions (`allOf`, `anyOf`,
   `oneOf`) ([Issue 265](https://github.com/muehmar/gradle-openapi-schema/issues/265)).
-* Conversions for mappings of maps as additional property is currently not supported.
+* Conversions for mappings are not supported when the additional-property value type is itself a `Map` whose value type
+  requires a conversion (a nested map with a mapped value type). Conversions for other additional-property types are
+  supported (see [#307](https://github.com/muehmar/gradle-openapi-schema/issues/307)).

--- a/doc/130_change_log.md
+++ b/doc/130_change_log.md
@@ -1,5 +1,8 @@
 ## Change Log
 
+* next
+    * [#397](https://github.com/muehmar/gradle-openapi-schema/issues/397) - Fix stale option names, wrong samples and
+      dead links in the documentation
 * 4.0.2
     * [#374](https://github.com/muehmar/gradle-openapi-schema/issues/374) - Fix NPE in `uniqueItems` validation for
       absent optional arrays

--- a/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/java/model/JavaAdditionalProperties.java
+++ b/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/java/model/JavaAdditionalProperties.java
@@ -38,7 +38,7 @@ public class JavaAdditionalProperties {
     if (javaType.isMapType() && javaType.hasApiTypeDeep()) {
       final String message =
           String.format(
-              "The pojo '%s' contains a Map as additional properties and a conversion is registered with mapping, which is currently not supported. This should be fixed with: https://github.com/muehmar/gradle-openapi-schema/issues/307.",
+              "The pojo '%s' has a Map as additional-property value type whose value type requires a conversion (a nested map with a mapped value type), which is currently not supported.",
               pojoName);
       throw new OpenApiGeneratorException(message);
     }


### PR DESCRIPTION
Fixes the doc-only findings collected in #397, verified against the current code and generated output.

## Changes

1. **doc/010** — warnings sample + option table now use `failOnMissingMappingConversion` (the real `WarningsConfig` property; the old `failOnMissingConversion` fails the build with "unknown property").
2. **doc/040** — `fold(...)` → `foldOneOf(...)` / `foldAnyOf(...)` (renamed in v2), and clarify that `oneOf` uses `foldOneOf` while `anyOf` with discriminator uses `foldAnyOf`.
3. **doc/070** — enabling validation is now `validation { enabled = true }` (was the nonexistent `enableValidation`).
4. **doc/040** — construction sample uses the real `fullAdminAndOrUserDtoBuilder()` (suffix included) with the matching `setAnyOfContainer` / anyOf container, instead of the nonexistent `fullAdminOrUserBuilder()` mixing a oneOf DTO with an anyOf container.
5. **doc/091** — the "wrapped array without name" sample now wraps in `<books>` (the property name), matching the item name and the adjacent explanatory text (confirmed by `ArraySerialisationTest`).
6. **Dead links / anchors** — fix the `spring-example` link (→ `springboot3-example`), `TestValidation.java` → `ValidationTest.java` with `../` prefixes, and several cross-file anchors in doc/010 and doc/030 (incremental build, validation, nullability, configuration, conversions).
7. **doc/110 + `JavaAdditionalProperties`** — reconcile with the completed #307 change: narrow the limitation to the actual remaining case (a nested map whose value type requires a conversion) and reword the leftover guard message so it no longer points at the already-closed #307.

Also adds a `next` changelog entry.

Docs-only apart from the one exception-message reword; `:plugin:compileJava` passes.

Issue: #397