### PR TITLE
Support referenced files containing only schemas (#342)

### DIFF
--- a/doc/020_openapi_support.md
+++ b/doc/020_openapi_support.md
@@ -25,3 +25,27 @@ type:
 ```
 
 Any other combination of types is currently not supported.
+
+## Referenced specifications
+
+Schemas may reference schemas in other files, the plugin will parse the referenced files transitively and generate
+classes for all their schemas too. A referenced file can either be a full OpenAPI document or a plain collection of
+schemas, i.e. the `openapi`, `info` and `components` fields are not required:
+
+```yaml
+# schemas/common.yml
+MyIsoDate:
+  type: "string"
+  format: "date"
+```
+
+referenced with
+
+```yaml
+dateFrom:
+  $ref: "./schemas/common.yml#/MyIsoDate"
+```
+
+Schemas nested under `components/schemas` (with or without the `openapi` and `info` fields) work as well. Files without
+an `openapi` field are interpreted according to the version declared in the main specification. The main specification
+itself must always be a full OpenAPI document.

--- a/doc/130_change_log.md
+++ b/doc/130_change_log.md
@@ -1,6 +1,8 @@
 ## Change Log
 
 * next
+    * [#342](https://github.com/muehmar/gradle-openapi-schema/issues/342) - Support referenced files containing only
+      schemas, i.e. without the `openapi`, `info` and `components` fields
     * [#397](https://github.com/muehmar/gradle-openapi-schema/issues/397) - Fix stale option names, wrong samples and
       dead links in the documentation
 * 4.0.2

--- a/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/mapper/reader/SwaggerSpecificationParser.java
+++ b/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/mapper/reader/SwaggerSpecificationParser.java
@@ -1,6 +1,10 @@
 package com.github.muehmar.gradle.openapi.generator.mapper.reader;
 
 import ch.bluecare.commons.data.PList;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.muehmar.gradle.openapi.generator.model.ParsedSpecification;
 import com.github.muehmar.gradle.openapi.generator.model.PojoSchema;
 import com.github.muehmar.gradle.openapi.generator.model.name.ComponentName;
@@ -8,6 +12,8 @@ import com.github.muehmar.gradle.openapi.generator.model.schema.OpenApiSchema;
 import com.github.muehmar.gradle.openapi.generator.model.schema.SchemaWrapper;
 import com.github.muehmar.gradle.openapi.generator.model.specification.MainDirectory;
 import com.github.muehmar.gradle.openapi.generator.model.specification.OpenApiSpec;
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.core.util.Yaml;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.parser.OpenAPIV3Parser;
 import io.swagger.v3.parser.core.models.ParseOptions;
@@ -15,11 +21,18 @@ import io.swagger.v3.parser.core.models.SwaggerParseResult;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 import org.gradle.api.GradleException;
 
 public class SwaggerSpecificationParser implements SpecificationParser {
+  private static final String OPENAPI_FIELD = "openapi";
+  private static final String COMPONENTS_FIELD = "components";
+  private static final String SCHEMAS_FIELD = "schemas";
+
   private final SpecificationReader specReader;
   private final String pojoSuffix;
+
+  private final AtomicReference<String> mainOpenApiVersion = new AtomicReference<>();
 
   public SwaggerSpecificationParser(SpecificationReader specReader, String pojoSuffix) {
     this.specReader = specReader;
@@ -29,7 +42,8 @@ public class SwaggerSpecificationParser implements SpecificationParser {
   @Override
   public ParsedSpecification parse(MainDirectory mainDirectory, OpenApiSpec inputSpec) {
     final String specString = specReader.read(mainDirectory, inputSpec);
-    final OpenAPI openAPI = parseSpec(specString);
+    final String documentString = normalizeOpenApiString(mainDirectory, inputSpec, specString);
+    final OpenAPI openAPI = parseSpec(documentString);
     return parse(inputSpec, openAPI);
   }
 
@@ -47,6 +61,81 @@ public class SwaggerSpecificationParser implements SpecificationParser {
                 new PojoSchema(
                     ComponentName.fromSchemaStringAndSuffix(entry.getKey(), pojoSuffix),
                     OpenApiSchema.wrapSchema(new SchemaWrapper(spec, entry.getValue()))));
+  }
+
+  /**
+   * Returns a full OpenAPI document unchanged. A schema-only file (schemas at the root or under
+   * 'components/schemas', without an 'openapi' field) is wrapped into a synthetic document
+   * inheriting the main specification's version.
+   */
+  private String normalizeOpenApiString(
+      MainDirectory mainDirectory, OpenApiSpec spec, String specString) {
+    return readObjectNode(specString)
+        .map(root -> normalizeOpenApiString(mainDirectory, spec, specString, root))
+        .orElse(specString);
+  }
+
+  private String normalizeOpenApiString(
+      MainDirectory mainDirectory, OpenApiSpec spec, String specString, ObjectNode root) {
+    final Optional<String> documentVersion =
+        Optional.ofNullable(root.get(OPENAPI_FIELD))
+            .filter(JsonNode::isTextual)
+            .map(JsonNode::asText);
+
+    return documentVersion
+        .map(
+            version -> {
+              mainOpenApiVersion.compareAndSet(null, version);
+              return specString;
+            })
+        .orElseGet(() -> wrapSchemasAsDocument(mainDirectory, spec, root));
+  }
+
+  private Optional<ObjectNode> readObjectNode(String specString) {
+    final ObjectMapper mapper = specString.trim().startsWith("{") ? Json.mapper() : Yaml.mapper();
+    try {
+      final JsonNode node = mapper.readTree(specString);
+      return node instanceof ObjectNode ? Optional.of((ObjectNode) node) : Optional.empty();
+    } catch (JsonProcessingException e) {
+      return Optional.empty();
+    }
+  }
+
+  private String wrapSchemasAsDocument(
+      MainDirectory mainDirectory, OpenApiSpec spec, ObjectNode root) {
+    final String version =
+        Optional.ofNullable(mainOpenApiVersion.get())
+            .orElseThrow(
+                () ->
+                    new GradleException(
+                        String.format(
+                            "The specification '%s' does not contain the 'openapi' field. Only"
+                                + " referenced specifications may omit it, the main specification"
+                                + " must be a full OpenAPI document.",
+                            spec.asPathWithMainDirectory(mainDirectory))));
+
+    final ObjectMapper mapper = Yaml.mapper();
+    final ObjectNode document = mapper.createObjectNode();
+    document.put(OPENAPI_FIELD, version);
+    final ObjectNode info = document.putObject("info");
+    info.put("title", "Referenced schemas");
+    info.put("version", "-");
+    document.putObject("paths");
+    if (root.has(COMPONENTS_FIELD)) {
+      document.set(COMPONENTS_FIELD, root.get(COMPONENTS_FIELD));
+    } else {
+      document.putObject(COMPONENTS_FIELD).set(SCHEMAS_FIELD, root);
+    }
+
+    try {
+      return mapper.writeValueAsString(document);
+    } catch (JsonProcessingException e) {
+      throw new GradleException(
+          String.format(
+              "Unable to process the referenced specification '%s'.",
+              spec.asPathWithMainDirectory(mainDirectory)),
+          e);
+    }
   }
 
   private OpenAPI parseSpec(String inputSpec) {

--- a/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/mapper/SpecificationMapperImplTest.java
+++ b/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/mapper/SpecificationMapperImplTest.java
@@ -148,6 +148,23 @@ class SpecificationMapperImplTest {
   }
 
   @Test
+  void map_when_remoteReferencedFilesWithoutOpenApiField_then_allPojosCorrectMapped() {
+    final PList<Pojo> pojos =
+        ResourceSchemaMappingTestUtil.mapSchema(
+            "/specifications/remote-ref-schema-only", "main.yml");
+
+    assertEquals(3, pojos.size());
+    assertEquals(
+        PList.of("AddressDto", "GroupDto", "MemberDto"),
+        pojos.map(Pojo::getName).map(ComponentName::getPojoName).map(PojoName::asString));
+
+    final ObjectPojo groupPojo = (ObjectPojo) pojos.apply(1);
+    final Optional<PojoMember> dateFrom =
+        groupPojo.getMembers().find(member -> member.getName().asString().equals("dateFrom"));
+    assertEquals(Optional.of(StringType.ofFormat(DATE)), dateFrom.map(PojoMember::getType));
+  }
+
+  @Test
   void map_when_calledWithRealOpenApiSchemas_then_allPojosCorrectMapped() {
     final PList<Pojo> pojos =
         ResourceSchemaMappingTestUtil.mapSchema("/integration/completespec", "openapi.yml");

--- a/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/mapper/reader/SwaggerSpecificationParserTest.java
+++ b/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/mapper/reader/SwaggerSpecificationParserTest.java
@@ -1,0 +1,167 @@
+package com.github.muehmar.gradle.openapi.generator.mapper.reader;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ch.bluecare.commons.data.PList;
+import com.github.muehmar.gradle.openapi.generator.model.ParsedSpecification;
+import com.github.muehmar.gradle.openapi.generator.model.PojoSchema;
+import com.github.muehmar.gradle.openapi.generator.model.specification.MainDirectory;
+import com.github.muehmar.gradle.openapi.generator.model.specification.OpenApiSpec;
+import io.swagger.v3.oas.models.SpecVersion;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import org.gradle.api.GradleException;
+import org.junit.jupiter.api.Test;
+
+class SwaggerSpecificationParserTest {
+  private static final MainDirectory MAIN_DIRECTORY = MainDirectory.fromString("specs");
+
+  private static final String MAIN_SPEC_V30 =
+      "openapi: \"3.0.0\"\n"
+          + "info: { }\n"
+          + "paths: { }\n"
+          + "components:\n"
+          + "  schemas:\n"
+          + "    Group:\n"
+          + "      properties:\n"
+          + "        dateFrom:\n"
+          + "          $ref: 'schemas.yml#/IsoDate'\n";
+
+  private static final String SCHEMA_ONLY_SPEC =
+      "IsoDate:\n"
+          + "  type: string\n"
+          + "  format: date\n"
+          + "Address:\n"
+          + "  properties:\n"
+          + "    street:\n"
+          + "      type: string\n";
+
+  @Test
+  void parse_when_referencedFileContainsOnlySchemas_then_allSchemasParsed() {
+    final SwaggerSpecificationParser parser =
+        parserWithFiles(files("main.yml", MAIN_SPEC_V30, "schemas.yml", SCHEMA_ONLY_SPEC));
+    parser.parse(MAIN_DIRECTORY, spec("main.yml"));
+
+    final ParsedSpecification parsed = parser.parse(MAIN_DIRECTORY, spec("schemas.yml"));
+
+    assertEquals(
+        PList.of("AddressDto", "IsoDateDto"),
+        parsed
+            .getPojoSchemas()
+            .map(pojoSchema -> pojoSchema.getPojoName().asString())
+            .sort(Comparator.naturalOrder()));
+  }
+
+  @Test
+  void parse_when_referencedFileContainsOnlySchemas_then_specVersionOfMainSpecInherited() {
+    final SwaggerSpecificationParser parser =
+        parserWithFiles(files("main.yml", MAIN_SPEC_V30, "schemas.yml", SCHEMA_ONLY_SPEC));
+    parser.parse(MAIN_DIRECTORY, spec("main.yml"));
+
+    final ParsedSpecification parsed = parser.parse(MAIN_DIRECTORY, spec("schemas.yml"));
+
+    assertEquals(
+        PList.of(SpecVersion.V30, SpecVersion.V30),
+        parsed
+            .getPojoSchemas()
+            .map(PojoSchema::getSchema)
+            .map(schema -> schema.getDelegateSchema().getSpecVersion()));
+  }
+
+  @Test
+  void parse_when_mainSpecIsV31_then_specVersionV31InheritedForSchemaOnlyFile() {
+    final String mainSpecV31 = MAIN_SPEC_V30.replace("\"3.0.0\"", "\"3.1.0\"");
+    final SwaggerSpecificationParser parser =
+        parserWithFiles(files("main.yml", mainSpecV31, "schemas.yml", SCHEMA_ONLY_SPEC));
+    parser.parse(MAIN_DIRECTORY, spec("main.yml"));
+
+    final ParsedSpecification parsed = parser.parse(MAIN_DIRECTORY, spec("schemas.yml"));
+
+    assertEquals(
+        PList.of(SpecVersion.V31, SpecVersion.V31),
+        parsed
+            .getPojoSchemas()
+            .map(PojoSchema::getSchema)
+            .map(schema -> schema.getDelegateSchema().getSpecVersion()));
+  }
+
+  @Test
+  void parse_when_referencedFileContainsComponentsWithoutOpenApiField_then_allSchemasParsed() {
+    final String componentsOnlySpec =
+        "components:\n"
+            + "  schemas:\n"
+            + "    Member:\n"
+            + "      properties:\n"
+            + "        nickname:\n"
+            + "          type: string\n";
+    final SwaggerSpecificationParser parser =
+        parserWithFiles(files("main.yml", MAIN_SPEC_V30, "components.yml", componentsOnlySpec));
+    parser.parse(MAIN_DIRECTORY, spec("main.yml"));
+
+    final ParsedSpecification parsed = parser.parse(MAIN_DIRECTORY, spec("components.yml"));
+
+    assertEquals(
+        PList.of("MemberDto"),
+        parsed.getPojoSchemas().map(pojoSchema -> pojoSchema.getPojoName().asString()));
+  }
+
+  @Test
+  void parse_when_referencedJsonFileContainsOnlySchemas_then_allSchemasParsed() {
+    final String schemaOnlyJson = "{\"IsoDate\": {\"type\": \"string\", \"format\": \"date\"}}";
+    final SwaggerSpecificationParser parser =
+        parserWithFiles(files("main.yml", MAIN_SPEC_V30, "schemas.json", schemaOnlyJson));
+    parser.parse(MAIN_DIRECTORY, spec("main.yml"));
+
+    final ParsedSpecification parsed = parser.parse(MAIN_DIRECTORY, spec("schemas.json"));
+
+    assertEquals(
+        PList.of("IsoDateDto"),
+        parsed.getPojoSchemas().map(pojoSchema -> pojoSchema.getPojoName().asString()));
+  }
+
+  @Test
+  void parse_when_mainSpecWithoutOpenApiField_then_throwsWithClearMessage() {
+    final SwaggerSpecificationParser parser = parserWithFiles(files("main.yml", SCHEMA_ONLY_SPEC));
+
+    final GradleException exception =
+        assertThrows(GradleException.class, () -> parser.parse(MAIN_DIRECTORY, spec("main.yml")));
+
+    assertTrue(exception.getMessage().contains("does not contain the 'openapi' field"));
+  }
+
+  @Test
+  void parse_when_invalidContent_then_throwsParseError() {
+    final SwaggerSpecificationParser parser = parserWithFiles(files("main.yml", "\"unclosed: [ {"));
+
+    assertThrows(GradleException.class, () -> parser.parse(MAIN_DIRECTORY, spec("main.yml")));
+  }
+
+  private static OpenApiSpec spec(String fileName) {
+    return OpenApiSpec.fromPath(Path.of(fileName));
+  }
+
+  private static Map<String, String> files(String... pathAndContent) {
+    final Map<String, String> files = new HashMap<>();
+    for (int i = 0; i < pathAndContent.length; i += 2) {
+      files.put(pathAndContent[i], pathAndContent[i + 1]);
+    }
+    return files;
+  }
+
+  private static SwaggerSpecificationParser parserWithFiles(Map<String, String> files) {
+    final SpecificationReader reader =
+        (mainDirectory, specification) -> {
+          final Path path = specification.asPathWithMainDirectory(mainDirectory);
+          final String content = files.get(path.getFileName().toString());
+          if (content == null) {
+            throw new IllegalStateException("Unknown specification: " + path);
+          }
+          return content;
+        };
+    return new SwaggerSpecificationParser(reader, "Dto");
+  }
+}

--- a/plugin/src/test/resources/specifications/remote-ref-schema-only/components-only.yml
+++ b/plugin/src/test/resources/specifications/remote-ref-schema-only/components-only.yml
@@ -1,0 +1,8 @@
+components:
+  schemas:
+    Member:
+      required:
+        - nickname
+      properties:
+        nickname:
+          type: string

--- a/plugin/src/test/resources/specifications/remote-ref-schema-only/main.yml
+++ b/plugin/src/test/resources/specifications/remote-ref-schema-only/main.yml
@@ -1,0 +1,15 @@
+openapi: "3.0.0"
+info: { }
+
+paths: { }
+
+components:
+  schemas:
+    Group:
+      required:
+        - dateFrom
+      properties:
+        dateFrom:
+          $ref: 'schemas.yml#/IsoDate'
+        member:
+          $ref: 'components-only.yml#/components/schemas/Member'

--- a/plugin/src/test/resources/specifications/remote-ref-schema-only/schemas.yml
+++ b/plugin/src/test/resources/specifications/remote-ref-schema-only/schemas.yml
@@ -1,0 +1,10 @@
+IsoDate:
+  type: string
+  format: date
+
+Address:
+  required:
+    - street
+  properties:
+    street:
+      type: string


### PR DESCRIPTION
Closes #342.

## What

Files referenced via `$ref` no longer need to be full OpenAPI documents. A referenced file may now be a plain collection of schemas:

```yaml
# schemas/common.yml
MyIsoDate:
  type: "string"
  format: "date"
```

referenced with `$ref: "./schemas/common.yml#/MyIsoDate"`. Schemas nested under `components/schemas` (without the `openapi`/`info` fields) work as well.

## How

All changes are contained in `SwaggerSpecificationParser`. Before handing a file to swagger-parser, it is read into a JSON/YAML node:

- Files with an `openapi` field parse exactly as before.
- Files without one are treated as schema collections and wrapped into a synthetic OpenAPI document (root schemas moved under `components/schemas`; an existing `components` node is taken as-is), then fed through the unchanged parse path.
- The synthetic document inherits the **main specification's version**, so 3.0-vs-3.1 semantics (`nullable:` vs type arrays, `exclusiveMinimum`, enum handling) follow the main spec. This works because the worklist always parses the main spec first.
- A schema-only file used as the *main* spec now fails with a clear message instead of the cryptic "attribute openapi is missing".

## Tests

- New `SwaggerSpecificationParserTest`: both file shapes, JSON variant, 3.0 and 3.1 version inheritance, main-spec error, invalid-content error.
- New mapper-level test in `SpecificationMapperImplTest` with resources under `specifications/remote-ref-schema-only/`.

The example issue-reproduction test is **not** part of this PR: the example modules consume the released plugin, so it can only be added once this change is published. It is prepared on a separate branch targeting 4.1.0.

Docs: changelog entry under `next`, and a new "Referenced specifications" section in `doc/020_openapi_support.md`.