### PR TITLE
Fix #391: coerce non-string enum literals to strings for OpenAPI 3.1

### DIFF
--- a/doc/130_change_log.md
+++ b/doc/130_change_log.md
@@ -1,6 +1,8 @@
 ## Change Log
 
 * next
+    * [#391](https://github.com/muehmar/gradle-openapi-schema/issues/391) - Coerce non-string enum literals to strings
+      for `type: string` enums in OpenAPI 3.1 specs instead of failing with a `ClassCastException`
     * [#342](https://github.com/muehmar/gradle-openapi-schema/issues/342) - Support referenced files containing only
       schemas, i.e. without the `openapi`, `info` and `components` fields
     * [#397](https://github.com/muehmar/gradle-openapi-schema/issues/397) - Fix stale option names, wrong samples and

--- a/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/model/schema/EnumSchema.java
+++ b/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/model/schema/EnumSchema.java
@@ -40,7 +40,7 @@ public class EnumSchema implements OpenApiSchema {
               schema,
               enums.stream()
                   .filter(Objects::nonNull)
-                  .map(String.class::cast)
+                  .map(String::valueOf)
                   .collect(PList.collector()),
               enums.stream().anyMatch(Objects::isNull));
       return Optional.of(enumSchema);

--- a/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/model/schema/EnumSchemaTest.java
+++ b/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/model/schema/EnumSchemaTest.java
@@ -16,8 +16,11 @@ import com.github.muehmar.gradle.openapi.generator.model.name.Name;
 import com.github.muehmar.gradle.openapi.generator.model.pojo.EnumPojo;
 import com.github.muehmar.gradle.openapi.generator.model.type.EnumType;
 import com.github.muehmar.gradle.openapi.generator.model.type.EnumTypeBuilder;
+import io.swagger.v3.oas.models.SpecVersion;
+import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
 import java.util.Arrays;
+import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 class EnumSchemaTest {
@@ -58,6 +61,26 @@ class EnumSchemaTest {
     assertEquals(expectedEnumType, result.getType());
     assertEquals(Nullability.NOT_NULLABLE, result.getType().getNullability());
     assertEquals(UnmappedItems.empty(), result.getUnmappedItems());
+  }
+
+  @Test
+  void mapToPojo_when_v31StringEnumWithNonStringLiterals_then_literalsCoercedToString() {
+    final Schema<Object> enumSchema = new Schema<>();
+    enumSchema.setSpecVersion(SpecVersion.V31);
+    enumSchema.setTypes(Collections.singleton(SchemaType.STRING.asString()));
+    enumSchema.setEnum(Arrays.asList(1, 2));
+
+    final PojoSchema pojoSchema =
+        new PojoSchema(componentName("NumberValues", "Dto"), wrap(enumSchema));
+
+    final MapContext mapContext = pojoSchema.mapToPojo();
+
+    final UnresolvedMapResult unresolvedMapResult = mapContext.getUnresolvedMapResult();
+    assertEquals(1, unresolvedMapResult.getPojos().size());
+
+    final EnumPojo expectedPojo =
+        EnumPojo.of(pojoSchema.getName(), "", Nullability.NOT_NULLABLE, PList.of("1", "2"));
+    assertEquals(expectedPojo, unresolvedMapResult.getPojos().apply(0));
   }
 
   @Test


### PR DESCRIPTION
## Summary

`EnumSchema.wrap` mapped `type: string` enum values with `String.class::cast`. The OpenAPI 3.0 parser coerces YAML literals to strings, but the 3.1 parser keeps native types, so a `type: string` enum with non-string literals crashed generation with a `ClassCastException`:

```yaml
openapi: "3.1.0"
# ...
NumberValues:
  type: string
  enum: [1, 2]
```

The identical schema in a 3.0.0 spec worked — merely changing the version string broke generation.

## Fix

Replace `String.class::cast` with `String::valueOf`, coercing the (already non-null-filtered) literals to strings and matching the 3.0 behaviour.

## Tests

- Plugin test `EnumSchemaTest.mapToPojo_when_v31StringEnumWithNonStringLiterals_then_literalsCoercedToString` — a V31 `type: string` enum with integer literals now maps to string enum values instead of throwing.
- Changelog entry added under `next`.

The end-to-end example issue-reproduction test lives on `examples-4.1.0` (it needs the released 4.1.0 plugin), verified locally against a Maven Local snapshot on both Jackson 3 and Jackson 2.19.

Closes #391