### PR TITLE
fix: support required additional properties with nullable value schema

### DIFF
--- a/doc/130_change_log.md
+++ b/doc/130_change_log.md
@@ -1,6 +1,8 @@
 ## Change Log
 
 * next
+    * [#394](https://github.com/muehmar/gradle-openapi-schema/issues/394) - Fix uncompilable generated code and
+      incorrect validation for required additional properties with a nullable value schema
     * [#391](https://github.com/muehmar/gradle-openapi-schema/issues/391) - Coerce non-string enum literals to strings
       for `type: string` enums in OpenAPI 3.1 specs instead of failing with a `ClassCastException`
     * [#342](https://github.com/muehmar/gradle-openapi-schema/issues/342) - Support referenced files containing only

--- a/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/builder/RequiredAdditionalPropertiesSetterGenerator.java
+++ b/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/builder/RequiredAdditionalPropertiesSetterGenerator.java
@@ -1,10 +1,12 @@
 package com.github.muehmar.gradle.openapi.generator.java.generator.pojo.builder;
 
+import static com.github.muehmar.gradle.openapi.generator.java.generator.shared.jackson.JacksonAnnotationGenerator.jsonIgnore;
 import static io.github.muehmar.codegenerator.Generator.newLine;
 import static io.github.muehmar.codegenerator.java.JavaModifier.PRIVATE;
 import static io.github.muehmar.codegenerator.java.JavaModifier.PUBLIC;
 import static io.github.muehmar.codegenerator.java.MethodGen.Argument.argument;
 
+import com.github.muehmar.gradle.openapi.generator.java.generator.pojo.RefsGenerator;
 import com.github.muehmar.gradle.openapi.generator.java.model.pojo.JavaObjectPojo;
 import com.github.muehmar.gradle.openapi.generator.java.model.pojo.JavaRequiredAdditionalProperty;
 import com.github.muehmar.gradle.openapi.generator.settings.PojoSettings;
@@ -26,6 +28,15 @@ public class RequiredAdditionalPropertiesSetterGenerator {
 
   private static Generator<JavaRequiredAdditionalProperty, PojoSettings>
       requiredAdditionalPropertiesSetter() {
+    return normalSetter()
+        .append(
+            Generator.<JavaRequiredAdditionalProperty, PojoSettings>emptyGen()
+                .appendSingleBlankLine()
+                .append(optionalSetter())
+                .filter(JavaRequiredAdditionalProperty::isNullable));
+  }
+
+  private static Generator<JavaRequiredAdditionalProperty, PojoSettings> normalSetter() {
     return MethodGenBuilder.<JavaRequiredAdditionalProperty, PojoSettings>create()
         .modifiers((p, s) -> JavaModifiers.of(s.isEnableStagedBuilder() ? PRIVATE : PUBLIC))
         .noGenericTypes()
@@ -38,6 +49,31 @@ public class RequiredAdditionalPropertiesSetterGenerator {
                 String.format(
                     "return addAdditionalProperty(\"%s\", %s);", rp.getName(), rp.getName()))
         .build();
+  }
+
+  private static Generator<JavaRequiredAdditionalProperty, PojoSettings> optionalSetter() {
+    return Generator.<JavaRequiredAdditionalProperty, PojoSettings>emptyGen()
+        .append(jsonIgnore())
+        .append(
+            MethodGenBuilder.<JavaRequiredAdditionalProperty, PojoSettings>create()
+                .modifiers((p, s) -> JavaModifiers.of(s.isEnableStagedBuilder() ? PRIVATE : PUBLIC))
+                .noGenericTypes()
+                .returnType("Builder")
+                .methodName(RequiredAdditionalPropertiesSetterGenerator::createMethodName)
+                .singleArgument(
+                    rp ->
+                        argument(
+                            String.format(
+                                "Optional<%s>", rp.getJavaType().getParameterizedClassName()),
+                            rp.getName()))
+                .doesNotThrow()
+                .content(
+                    rp ->
+                        String.format(
+                            "return addAdditionalProperty(\"%s\", %s.orElse(null));",
+                            rp.getName(), rp.getName()))
+                .build())
+        .append(RefsGenerator.optionalRef());
   }
 
   private static String createMethodName(JavaRequiredAdditionalProperty rp, PojoSettings settings) {

--- a/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/getter/RequiredAdditionalPropertiesGetter.java
+++ b/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/getter/RequiredAdditionalPropertiesGetter.java
@@ -13,6 +13,7 @@ import com.github.muehmar.gradle.openapi.generator.java.generator.pojo.RefsGener
 import com.github.muehmar.gradle.openapi.generator.java.generator.shared.DeprecatedMethodGenerator;
 import com.github.muehmar.gradle.openapi.generator.java.generator.shared.Filters;
 import com.github.muehmar.gradle.openapi.generator.java.generator.shared.SettingsFunctions;
+import com.github.muehmar.gradle.openapi.generator.java.generator.shared.validation.ValidationAnnotationGenerator;
 import com.github.muehmar.gradle.openapi.generator.java.model.pojo.JavaObjectPojo;
 import com.github.muehmar.gradle.openapi.generator.java.model.pojo.JavaRequiredAdditionalProperty;
 import com.github.muehmar.gradle.openapi.generator.settings.PojoSettings;
@@ -29,33 +30,75 @@ public class RequiredAdditionalPropertiesGetter {
 
   private static Generator<JavaRequiredAdditionalProperty, PojoSettings> annotatedGetter() {
     return Generator.<JavaRequiredAdditionalProperty, PojoSettings>emptyGen()
-        .append(validAnnotationForType(), JavaRequiredAdditionalProperty::getJavaType)
+        .append(
+            Generator.<JavaRequiredAdditionalProperty, PojoSettings>emptyGen()
+                .append(validAnnotationForType(), JavaRequiredAdditionalProperty::getJavaType)
+                .filter(JavaRequiredAdditionalProperty::isNotNullable))
         .append(
             notNullAnnotation(JavaRequiredAdditionalProperty.class)
-                .filter(JavaRequiredAdditionalProperty::isAnyType))
+                .filter(JavaRequiredAdditionalProperty::isAnyType)
+                .filter(JavaRequiredAdditionalProperty::isNotNullable))
         .append(jsonIgnore())
         .append(getter())
         .appendSingleBlankLine()
         .append(notNullValidationGetterForSpecificType())
         .appendSingleBlankLine()
+        .append(presenceValidationGetterForNullableType())
+        .appendSingleBlankLine()
+        .append(deepValidationGetterForNullableType())
+        .appendSingleBlankLine()
         .append(correctTypeValidationGetterForSpecificType());
+  }
+
+  private static Generator<JavaRequiredAdditionalProperty, PojoSettings>
+      presenceValidationGetterForNullableType() {
+    return DeprecatedMethodGenerator
+        .<JavaRequiredAdditionalProperty>deprecatedJavaDocAndAnnotationForValidationMethod()
+        .append(assertTrue(prop -> String.format("Is required but missing: %s", prop.getName())))
+        .append(
+            MethodGenBuilder.<JavaRequiredAdditionalProperty, PojoSettings>create()
+                .modifiers(SettingsFunctions::validationMethodModifiers)
+                .noGenericTypes()
+                .returnType("boolean")
+                .methodName(prop -> String.format("is%sPresent", prop.getName().startUpperCase()))
+                .noArguments()
+                .doesNotThrow()
+                .content(
+                    (prop, s, w) ->
+                        w.println(
+                            "return %s.containsKey(\"%s\");",
+                            additionalPropertiesName(), prop.getName()))
+                .build())
+        .filter(JavaRequiredAdditionalProperty::isNullable)
+        .filter(Filters.isValidationEnabled());
   }
 
   private static Generator<JavaRequiredAdditionalProperty, PojoSettings> getter() {
     return MethodGenBuilder.<JavaRequiredAdditionalProperty, PojoSettings>create()
         .modifiers(PUBLIC)
         .noGenericTypes()
-        .returnType(prop -> prop.getJavaType().getParameterizedClassName())
+        .returnType(RequiredAdditionalPropertiesGetter::getterReturnType)
         .methodName(prop -> String.format("get%s", prop.getName().startUpperCase()))
         .noArguments()
         .doesNotThrow()
         .content(getterContent())
         .build()
-        .append(RefsGenerator.javaTypeRefs(), JavaRequiredAdditionalProperty::getJavaType);
+        .append(RefsGenerator.javaTypeRefs(), JavaRequiredAdditionalProperty::getJavaType)
+        .append(
+            RefsGenerator.<JavaRequiredAdditionalProperty, PojoSettings>optionalRef()
+                .filter(JavaRequiredAdditionalProperty::isNullable));
+  }
+
+  private static String getterReturnType(JavaRequiredAdditionalProperty prop) {
+    final String className = prop.getJavaType().getParameterizedClassName().asString();
+    return prop.isNullable() ? String.format("Optional<%s>", className) : className;
   }
 
   private static Generator<JavaRequiredAdditionalProperty, PojoSettings> getterContent() {
-    return getterContentForAnyType().append(getterContentForSpecificType());
+    return getterContentForAnyType()
+        .append(getterContentForSpecificType())
+        .append(getterContentForNullableAnyType())
+        .append(getterContentForNullableSpecificType());
   }
 
   private static Generator<JavaRequiredAdditionalProperty, PojoSettings> getterContentForAnyType() {
@@ -63,7 +106,8 @@ public class RequiredAdditionalPropertiesGetter {
         .append(
             (prop, s, w) ->
                 w.println("return %s.get(\"%s\");", additionalPropertiesName(), prop.getName()))
-        .filter(JavaRequiredAdditionalProperty::isAnyType);
+        .filter(JavaRequiredAdditionalProperty::isAnyType)
+        .filter(JavaRequiredAdditionalProperty::isNotNullable);
   }
 
   private static Generator<JavaRequiredAdditionalProperty, PojoSettings>
@@ -82,7 +126,72 @@ public class RequiredAdditionalPropertiesGetter {
         .append(constant("catch (ClassCastException e) {"))
         .append(constant("return null;"), 1)
         .append(constant("}"))
-        .filter(JavaRequiredAdditionalProperty::isNotAnyType);
+        .filter(JavaRequiredAdditionalProperty::isNotAnyType)
+        .filter(JavaRequiredAdditionalProperty::isNotNullable);
+  }
+
+  private static Generator<JavaRequiredAdditionalProperty, PojoSettings>
+      getterContentForNullableAnyType() {
+    return Generator.<JavaRequiredAdditionalProperty, PojoSettings>emptyGen()
+        .append(
+            (prop, s, w) ->
+                w.println(
+                    "return Optional.ofNullable(%s.get(\"%s\"));",
+                    additionalPropertiesName(), prop.getName()))
+        .filter(JavaRequiredAdditionalProperty::isAnyType)
+        .filter(JavaRequiredAdditionalProperty::isNullable);
+  }
+
+  private static Generator<JavaRequiredAdditionalProperty, PojoSettings>
+      getterContentForNullableSpecificType() {
+    return Generator.<JavaRequiredAdditionalProperty, PojoSettings>emptyGen()
+        .append(
+            (prop, s, w) ->
+                w.println(
+                    "return Optional.ofNullable(%s.get(\"%s\"))",
+                    additionalPropertiesName(), prop.getName()))
+        .append(
+            (prop, s, w) ->
+                w.println(
+                    ".filter(%s.class::isInstance)",
+                    prop.getJavaType().getQualifiedClassName().getClassName()),
+            2)
+        .append(
+            (prop, s, w) ->
+                w.println(
+                    ".map(value -> (%s) value);", prop.getJavaType().getParameterizedClassName()),
+            2)
+        .filter(JavaRequiredAdditionalProperty::isNotAnyType)
+        .filter(JavaRequiredAdditionalProperty::isNullable);
+  }
+
+  private static Generator<JavaRequiredAdditionalProperty, PojoSettings>
+      deepValidationGetterForNullableType() {
+    return DeprecatedMethodGenerator
+        .<JavaRequiredAdditionalProperty>deprecatedJavaDocAndAnnotationForValidationMethod()
+        .append(jsonIgnore())
+        .append(validAnnotationForType(), JavaRequiredAdditionalProperty::getJavaType)
+        .append(
+            MethodGenBuilder.<JavaRequiredAdditionalProperty, PojoSettings>create()
+                .modifiers(SettingsFunctions::validationMethodModifiers)
+                .noGenericTypes()
+                .returnType(prop -> prop.getJavaType().getParameterizedClassName().asString())
+                .methodName(
+                    (prop, settings) ->
+                        String.format(
+                            "get%s%s",
+                            prop.getName().startUpperCase(),
+                            settings.getValidationMethods().getGetterSuffix()))
+                .noArguments()
+                .doesNotThrow()
+                .content(
+                    (prop, s, w) ->
+                        w.println("return get%s().orElse(null);", prop.getName().startUpperCase()))
+                .build())
+        .append(RefsGenerator.javaTypeRefs(), JavaRequiredAdditionalProperty::getJavaType)
+        .filter(prop -> ValidationAnnotationGenerator.shouldValidateDeep(prop.getJavaType()))
+        .filter(JavaRequiredAdditionalProperty::isNullable)
+        .filter(Filters.isValidationEnabled());
   }
 
   private static Generator<JavaRequiredAdditionalProperty, PojoSettings>
@@ -105,6 +214,7 @@ public class RequiredAdditionalPropertiesGetter {
                 .build())
         .append(RefsGenerator.javaTypeRefs(), JavaRequiredAdditionalProperty::getJavaType)
         .filter(JavaRequiredAdditionalProperty::isNotAnyType)
+        .filter(JavaRequiredAdditionalProperty::isNotNullable)
         .filter(Filters.isValidationEnabled());
   }
 

--- a/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/java/generator/shared/validation/ValidationAnnotationGenerator.java
+++ b/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/java/generator/shared/validation/ValidationAnnotationGenerator.java
@@ -86,7 +86,7 @@ public class ValidationAnnotationGenerator {
         .filter(ValidationAnnotationGenerator::shouldValidateDeep);
   }
 
-  private static boolean shouldValidateDeep(JavaType javaType) {
+  public static boolean shouldValidateDeep(JavaType javaType) {
     if (javaType instanceof JavaObjectType) {
       return true;
     } else if (javaType instanceof JavaArrayType) {

--- a/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/java/generator/shared/validation/validator/ConstraintConditions.java
+++ b/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/java/generator/shared/validation/validator/ConstraintConditions.java
@@ -12,6 +12,7 @@ import static com.github.muehmar.gradle.openapi.util.Booleans.not;
 import static io.github.muehmar.codegenerator.writer.Writer.javaWriter;
 
 import com.github.muehmar.gradle.openapi.generator.java.JavaEscaper;
+import com.github.muehmar.gradle.openapi.generator.java.model.JavaAdditionalProperties;
 import com.github.muehmar.gradle.openapi.generator.java.model.name.IsNotNullFlagName;
 import com.github.muehmar.gradle.openapi.generator.java.model.name.IsPresentFlagName;
 import com.github.muehmar.gradle.openapi.generator.java.model.name.JavaName;
@@ -274,13 +275,29 @@ class ConstraintConditions {
         return writer.print("false", propertyValue.getAccessor());
       }
     } else if (propertyValue.isRequiredAndNullable()) {
-      final JavaName isPresentFlagName =
-          IsPresentFlagName.fromName(propertyValue.getName()).getName();
-      if (hasNoOtherConditions) {
-        return writer.print("(%s != null || %s)", propertyValue.getAccessor(), isPresentFlagName);
-      } else {
-        return writer.print("%s", isPresentFlagName);
+      if (propertyValue.isAdditionalProperty()) {
+        // A required nullable additional property is valid iff present; a present but null value
+        // is spec-valid. The accessor also yields null for a value of the wrong type (the backing
+        // map is a Map<String, Object>), which must not count as valid - also when isValid() is
+        // called directly for deep validation, bypassing the correct-type bean-validation method.
+        // As the fall-through of the null-guarded conditions the accessor is known to yield null,
+        // so a null raw value decides; standalone, a non-null raw value must additionally be
+        // readable through the typed accessor.
+        final JavaName additionalPropertiesName =
+            JavaAdditionalProperties.additionalPropertiesName();
+        final String rawValueIsNull =
+            String.format(
+                "%s.get(\"%s\") == null", additionalPropertiesName, propertyValue.getName());
+        final String nullOrReadableValueCheck =
+            hasNoOtherConditions
+                ? String.format("(%s || %s != null)", rawValueIsNull, propertyValue.getAccessor())
+                : rawValueIsNull;
+        return writer.print(
+            "%s.containsKey(\"%s\") && %s",
+            additionalPropertiesName, propertyValue.getName(), nullOrReadableValueCheck);
       }
+      // A required nullable member is valid iff present; a present but null value is spec-valid.
+      return writer.print("%s", IsPresentFlagName.fromName(propertyValue.getName()).getName());
     } else if (propertyValue.isOptionalAndNotNullable()) {
       return writer.print("%s", IsNotNullFlagName.fromName(propertyValue.getName()).getName());
     } else {

--- a/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/java/generator/shared/validation/validator/PropertyValue.java
+++ b/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/java/generator/shared/validation/validator/PropertyValue.java
@@ -29,6 +29,7 @@ public class PropertyValue {
   Nullability nullability;
   Necessity necessity;
   boolean isNested;
+  boolean isAdditionalProperty;
 
   public static PropertyValue fromJavaMember(JavaPojoMember member) {
     return fullPropertyValueBuilder()
@@ -39,6 +40,7 @@ public class PropertyValue {
         .nullability(member.getNullability())
         .necessity(member.getNecessity())
         .isNested(false)
+        .isAdditionalProperty(false)
         .build();
   }
 
@@ -49,16 +51,19 @@ public class PropertyValue {
 
   public static PropertyValue fromRequiredAdditionalProperty(
       JavaRequiredAdditionalProperty additionalProperty, JavaPojoName pojoName) {
+    final String getter =
+        String.format("%s()", additionalProperty.getName().startUpperCase().prefix("get"));
+    final String accessor = additionalProperty.isNullable() ? getter + ".orElse(null)" : getter;
     return fullPropertyValueBuilder()
         .propertyInfoName(
             PropertyInfoName.fromPojoNameAndMemberName(pojoName, additionalProperty.getName()))
         .name(additionalProperty.getName())
-        .accessor(
-            String.format("%s()", additionalProperty.getName().startUpperCase().prefix("get")))
+        .accessor(accessor)
         .type(additionalProperty.getJavaType())
-        .nullability(NOT_NULLABLE)
+        .nullability(additionalProperty.getJavaType().getNullability())
         .necessity(Necessity.REQUIRED)
         .isNested(false)
+        .isAdditionalProperty(true)
         .build();
   }
 
@@ -78,6 +83,7 @@ public class PropertyValue {
         .nullability(NOT_NULLABLE)
         .necessity(Necessity.REQUIRED)
         .isNested(false)
+        .isAdditionalProperty(false)
         .build();
   }
 
@@ -104,6 +110,7 @@ public class PropertyValue {
         .nullability(type.getNullability())
         .necessity(Necessity.OPTIONAL)
         .isNested(true)
+        .isAdditionalProperty(false)
         .build();
   }
 

--- a/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/java/model/pojo/JavaRequiredAdditionalProperty.java
+++ b/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/java/model/pojo/JavaRequiredAdditionalProperty.java
@@ -44,4 +44,12 @@ public class JavaRequiredAdditionalProperty {
   public boolean isNotAnyType() {
     return not(isAnyType());
   }
+
+  public boolean isNullable() {
+    return javaType.getNullability().isNullable();
+  }
+
+  public boolean isNotNullable() {
+    return not(isNullable());
+  }
 }

--- a/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/builder/RequiredAdditionalPropertiesSetterGeneratorTest.java
+++ b/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/builder/RequiredAdditionalPropertiesSetterGeneratorTest.java
@@ -3,6 +3,9 @@ package com.github.muehmar.gradle.openapi.generator.java.generator.pojo.builder;
 import static com.github.muehmar.gradle.openapi.generator.java.generator.pojo.builder.RequiredAdditionalPropertiesSetterGenerator.requiredAdditionalPropertiesSetterGenerator;
 import static com.github.muehmar.gradle.openapi.generator.java.model.pojo.JavaPojos.sampleObjectPojo1;
 import static com.github.muehmar.gradle.openapi.generator.java.model.type.JavaTypes.anyType;
+import static com.github.muehmar.gradle.openapi.generator.java.model.type.JavaTypes.nullableAnyType;
+import static com.github.muehmar.gradle.openapi.generator.java.model.type.JavaTypes.nullableStringType;
+import static com.github.muehmar.gradle.openapi.generator.java.model.type.JavaTypes.stringType;
 import static com.github.muehmar.gradle.openapi.generator.settings.TestPojoSettings.defaultTestSettings;
 import static com.github.muehmar.gradle.openapi.snapshot.SnapshotUtil.writerSnapshot;
 import static io.github.muehmar.codegenerator.writer.Writer.javaWriter;
@@ -31,6 +34,62 @@ class RequiredAdditionalPropertiesSetterGeneratorTest {
     final PList<JavaRequiredAdditionalProperty> requiredAdditionalProperties =
         PList.single(
             JavaRequiredAdditionalProperty.fromNameAndType(Name.ofString("prop1"), anyType()));
+
+    final Writer writer =
+        generator.generate(
+            sampleObjectPojo1().withRequiredAdditionalProperties(requiredAdditionalProperties),
+            defaultTestSettings(),
+            javaWriter());
+
+    expect.toMatchSnapshot(writerSnapshot(writer));
+  }
+
+  @Test
+  @SnapshotName("pojoWithRequiredNullableSpecificTypeProperty")
+  void generate_when_pojoWithRequiredNullableSpecificTypeProperty_then_optionalSetterGenerated() {
+    final Generator<JavaObjectPojo, PojoSettings> generator =
+        requiredAdditionalPropertiesSetterGenerator();
+    final PList<JavaRequiredAdditionalProperty> requiredAdditionalProperties =
+        PList.single(
+            JavaRequiredAdditionalProperty.fromNameAndType(
+                Name.ofString("prop1"), nullableStringType()));
+
+    final Writer writer =
+        generator.generate(
+            sampleObjectPojo1().withRequiredAdditionalProperties(requiredAdditionalProperties),
+            defaultTestSettings(),
+            javaWriter());
+
+    expect.toMatchSnapshot(writerSnapshot(writer));
+  }
+
+  @Test
+  @SnapshotName("pojoWithRequiredNullableAnyTypeProperty")
+  void generate_when_pojoWithRequiredNullableAnyTypeProperty_then_optionalSetterGenerated() {
+    final Generator<JavaObjectPojo, PojoSettings> generator =
+        requiredAdditionalPropertiesSetterGenerator();
+    final PList<JavaRequiredAdditionalProperty> requiredAdditionalProperties =
+        PList.single(
+            JavaRequiredAdditionalProperty.fromNameAndType(
+                Name.ofString("prop1"), nullableAnyType()));
+
+    final Writer writer =
+        generator.generate(
+            sampleObjectPojo1().withRequiredAdditionalProperties(requiredAdditionalProperties),
+            defaultTestSettings(),
+            javaWriter());
+
+    expect.toMatchSnapshot(writerSnapshot(writer));
+  }
+
+  @Test
+  @SnapshotName("pojoWithRequiredNotNullableSpecificTypeProperty")
+  void generate_when_pojoWithRequiredNotNullableSpecificTypeProperty_then_onlyRawSetter() {
+    final Generator<JavaObjectPojo, PojoSettings> generator =
+        requiredAdditionalPropertiesSetterGenerator();
+    final PList<JavaRequiredAdditionalProperty> requiredAdditionalProperties =
+        PList.single(
+            JavaRequiredAdditionalProperty.fromNameAndType(Name.ofString("prop1"), stringType()));
 
     final Writer writer =
         generator.generate(

--- a/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/builder/__snapshots__/RequiredAdditionalPropertiesSetterGeneratorTest.snap
+++ b/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/builder/__snapshots__/RequiredAdditionalPropertiesSetterGeneratorTest.snap
@@ -1,3 +1,42 @@
+pojoWithRequiredNotNullableSpecificTypeProperty=[
+.
+.
+private Builder setProp1(String prop1) {
+  return addAdditionalProperty("prop1", prop1);
+}
+]
+
+
+pojoWithRequiredNullableAnyTypeProperty=[
+com.fasterxml.jackson.annotation.JsonIgnore
+java.util.Optional
+
+private Builder setProp1(Object prop1) {
+  return addAdditionalProperty("prop1", prop1);
+}
+
+@JsonIgnore
+private Builder setProp1(Optional<Object> prop1) {
+  return addAdditionalProperty("prop1", prop1.orElse(null));
+}
+]
+
+
+pojoWithRequiredNullableSpecificTypeProperty=[
+com.fasterxml.jackson.annotation.JsonIgnore
+java.util.Optional
+
+private Builder setProp1(String prop1) {
+  return addAdditionalProperty("prop1", prop1);
+}
+
+@JsonIgnore
+private Builder setProp1(Optional<String> prop1) {
+  return addAdditionalProperty("prop1", prop1.orElse(null));
+}
+]
+
+
 pojoWithRequiredProperties=[
 .
 .

--- a/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/getter/RequiredAdditionalPropertiesGetterTest.java
+++ b/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/getter/RequiredAdditionalPropertiesGetterTest.java
@@ -3,6 +3,10 @@ package com.github.muehmar.gradle.openapi.generator.java.generator.pojo.getter;
 import static com.github.muehmar.gradle.openapi.generator.java.generator.pojo.getter.RequiredAdditionalPropertiesGetter.requiredAdditionalPropertiesGetter;
 import static com.github.muehmar.gradle.openapi.generator.java.model.pojo.JavaPojos.sampleObjectPojo1;
 import static com.github.muehmar.gradle.openapi.generator.java.model.type.JavaTypes.anyType;
+import static com.github.muehmar.gradle.openapi.generator.java.model.type.JavaTypes.nullableAnyType;
+import static com.github.muehmar.gradle.openapi.generator.java.model.type.JavaTypes.nullableObjectType;
+import static com.github.muehmar.gradle.openapi.generator.java.model.type.JavaTypes.nullableStringListType;
+import static com.github.muehmar.gradle.openapi.generator.java.model.type.JavaTypes.nullableStringType;
 import static com.github.muehmar.gradle.openapi.generator.settings.TestPojoSettings.defaultTestSettings;
 import static com.github.muehmar.gradle.openapi.snapshot.SnapshotUtil.writerSnapshot;
 import static io.github.muehmar.codegenerator.writer.Writer.javaWriter;
@@ -108,6 +112,74 @@ class RequiredAdditionalPropertiesGetterTest {
             .withRequiredAdditionalProperties(
                 PList.single(
                     new JavaRequiredAdditionalProperty(JavaName.fromString("prop1"), anyType())));
+
+    final Writer writer = generator.generate(pojo, defaultTestSettings(), javaWriter());
+
+    expect.toMatchSnapshot(writerSnapshot(writer));
+  }
+
+  @Test
+  @SnapshotName("requiredAdditionalNullableStringProperties")
+  void generate_when_requiredAdditionalNullableStringProperties_then_noNotNullAsObjectMethod() {
+    final Generator<JavaObjectPojo, PojoSettings> generator = requiredAdditionalPropertiesGetter();
+
+    final JavaObjectPojo pojo =
+        sampleObjectPojo1()
+            .withRequiredAdditionalProperties(
+                PList.single(
+                    new JavaRequiredAdditionalProperty(
+                        JavaName.fromString("prop1"), nullableStringType())));
+
+    final Writer writer = generator.generate(pojo, defaultTestSettings(), javaWriter());
+
+    expect.toMatchSnapshot(writerSnapshot(writer));
+  }
+
+  @Test
+  @SnapshotName("requiredAdditionalNullableObjectProperties")
+  void generate_when_requiredAdditionalNullableObjectProperties_then_validAnnotatedRawGetter() {
+    final Generator<JavaObjectPojo, PojoSettings> generator = requiredAdditionalPropertiesGetter();
+
+    final JavaObjectPojo pojo =
+        sampleObjectPojo1()
+            .withRequiredAdditionalProperties(
+                PList.single(
+                    new JavaRequiredAdditionalProperty(
+                        JavaName.fromString("prop1"), nullableObjectType())));
+
+    final Writer writer = generator.generate(pojo, defaultTestSettings(), javaWriter());
+
+    expect.toMatchSnapshot(writerSnapshot(writer));
+  }
+
+  @Test
+  @SnapshotName("requiredAdditionalNullableStringListProperties")
+  void generate_when_requiredAdditionalNullableStringListProperties_then_compilableCast() {
+    final Generator<JavaObjectPojo, PojoSettings> generator = requiredAdditionalPropertiesGetter();
+
+    final JavaObjectPojo pojo =
+        sampleObjectPojo1()
+            .withRequiredAdditionalProperties(
+                PList.single(
+                    new JavaRequiredAdditionalProperty(
+                        JavaName.fromString("prop1"), nullableStringListType())));
+
+    final Writer writer = generator.generate(pojo, defaultTestSettings(), javaWriter());
+
+    expect.toMatchSnapshot(writerSnapshot(writer));
+  }
+
+  @Test
+  @SnapshotName("requiredAdditionalNullableAnyTypeProperties")
+  void generate_when_requiredAdditionalNullableAnyTypeProperties_then_noNotNullAnnotation() {
+    final Generator<JavaObjectPojo, PojoSettings> generator = requiredAdditionalPropertiesGetter();
+
+    final JavaObjectPojo pojo =
+        sampleObjectPojo1()
+            .withRequiredAdditionalProperties(
+                PList.single(
+                    new JavaRequiredAdditionalProperty(
+                        JavaName.fromString("prop1"), nullableAnyType())));
 
     final Writer writer = generator.generate(pojo, defaultTestSettings(), javaWriter());
 

--- a/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/getter/__snapshots__/RequiredAdditionalPropertiesGetterTest.snap
+++ b/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/getter/__snapshots__/RequiredAdditionalPropertiesGetterTest.snap
@@ -11,6 +11,107 @@ public Object getProp1() {
 ]
 
 
+requiredAdditionalNullableAnyTypeProperties=[
+com.fasterxml.jackson.annotation.JsonIgnore
+java.util.Optional
+javax.validation.constraints.AssertTrue
+
+@JsonIgnore
+public Optional<Object> getProp1() {
+  return Optional.ofNullable(additionalProperties.get("prop1"));
+}
+
+@AssertTrue(message = "Is required but missing: prop1")
+private boolean isProp1Present() {
+  return additionalProperties.containsKey("prop1");
+}
+
+]
+
+
+requiredAdditionalNullableObjectProperties=[
+com.fasterxml.jackson.annotation.JsonIgnore
+java.util.Optional
+javax.validation.Valid
+javax.validation.constraints.AssertTrue
+
+@JsonIgnore
+public Optional<UserDto> getProp1() {
+  return Optional.ofNullable(additionalProperties.get("prop1"))
+      .filter(UserDto.class::isInstance)
+      .map(value -> (UserDto) value);
+}
+
+@AssertTrue(message = "Is required but missing: prop1")
+private boolean isProp1Present() {
+  return additionalProperties.containsKey("prop1");
+}
+
+@JsonIgnore
+@Valid
+private UserDto getProp1Raw() {
+  return getProp1().orElse(null);
+}
+
+@AssertTrue(message = "Value is not an instance of UserDto")
+private boolean isProp1CorrectType() {
+  Object value = additionalProperties.get("prop1");
+  return value == null || value instanceof UserDto;
+}
+]
+
+
+requiredAdditionalNullableStringListProperties=[
+com.fasterxml.jackson.annotation.JsonIgnore
+java.util.List
+java.util.Optional
+javax.validation.constraints.AssertTrue
+
+@JsonIgnore
+public Optional<List<String>> getProp1() {
+  return Optional.ofNullable(additionalProperties.get("prop1"))
+      .filter(List.class::isInstance)
+      .map(value -> (List<String>) value);
+}
+
+@AssertTrue(message = "Is required but missing: prop1")
+private boolean isProp1Present() {
+  return additionalProperties.containsKey("prop1");
+}
+
+@AssertTrue(message = "Value is not an instance of List")
+private boolean isProp1CorrectType() {
+  Object value = additionalProperties.get("prop1");
+  return value == null || value instanceof List;
+}
+]
+
+
+requiredAdditionalNullableStringProperties=[
+com.fasterxml.jackson.annotation.JsonIgnore
+java.util.Optional
+javax.validation.constraints.AssertTrue
+
+@JsonIgnore
+public Optional<String> getProp1() {
+  return Optional.ofNullable(additionalProperties.get("prop1"))
+      .filter(String.class::isInstance)
+      .map(value -> (String) value);
+}
+
+@AssertTrue(message = "Is required but missing: prop1")
+private boolean isProp1Present() {
+  return additionalProperties.containsKey("prop1");
+}
+
+@AssertTrue(message = "Value is not an instance of String")
+private boolean isProp1CorrectType() {
+  Object value = additionalProperties.get("prop1");
+  return value == null || value instanceof String;
+}
+]
+
+
 requiredAdditionalObjectProperties=[
 com.fasterxml.jackson.annotation.JsonIgnore
 javax.validation.Valid

--- a/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/validation/validator/ValidatorClassGeneratorTest.java
+++ b/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/validation/validator/ValidatorClassGeneratorTest.java
@@ -20,12 +20,21 @@ import com.github.muehmar.gradle.openapi.generator.java.model.member.JavaPojoMem
 import com.github.muehmar.gradle.openapi.generator.java.model.member.TestJavaPojoMembers;
 import com.github.muehmar.gradle.openapi.generator.java.model.pojo.JavaObjectPojo;
 import com.github.muehmar.gradle.openapi.generator.java.model.pojo.JavaPojos;
+import com.github.muehmar.gradle.openapi.generator.java.model.pojo.JavaRequiredAdditionalProperty;
+import com.github.muehmar.gradle.openapi.generator.java.model.type.JavaObjectType;
+import com.github.muehmar.gradle.openapi.generator.java.model.type.JavaStringType;
 import com.github.muehmar.gradle.openapi.generator.java.model.type.JavaTypes;
+import com.github.muehmar.gradle.openapi.generator.model.Nullability;
 import com.github.muehmar.gradle.openapi.generator.model.composition.UntypedDiscriminator;
 import com.github.muehmar.gradle.openapi.generator.model.constraints.Constraints;
 import com.github.muehmar.gradle.openapi.generator.model.constraints.PropertyCount;
+import com.github.muehmar.gradle.openapi.generator.model.constraints.Size;
 import com.github.muehmar.gradle.openapi.generator.model.name.Name;
+import com.github.muehmar.gradle.openapi.generator.model.name.PojoName;
+import com.github.muehmar.gradle.openapi.generator.model.type.StandardObjectType;
+import com.github.muehmar.gradle.openapi.generator.model.type.StringType;
 import com.github.muehmar.gradle.openapi.generator.settings.PojoSettings;
+import com.github.muehmar.gradle.openapi.generator.settings.TypeMappings;
 import com.github.muehmar.gradle.openapi.snapshot.SnapshotTest;
 import com.github.muehmar.gradle.openapi.snapshot.SnapshotUtil;
 import io.github.muehmar.codegenerator.Generator;
@@ -206,6 +215,85 @@ class ValidatorClassGeneratorTest {
 
     final JavaObjectPojo pojo =
         sampleObjectPojo1().withAdditionalProperties(JavaAdditionalProperties.notAllowed());
+
+    final Writer writer = generator.generate(pojo, defaultTestSettings(), javaWriter());
+
+    expect.toMatchSnapshot(writer.asString());
+  }
+
+  @Test
+  @SnapshotName("objectPojoWithRequiredNotNullableAdditionalProperty")
+  void generate_when_objectPojoWithRequiredNotNullableAdditionalProperty_then_correctOutput() {
+    final Generator<JavaObjectPojo, PojoSettings> generator = validationClassGenerator();
+
+    final JavaObjectPojo pojo =
+        sampleObjectPojo1()
+            .withRequiredAdditionalProperties(
+                PList.single(
+                    JavaRequiredAdditionalProperty.fromNameAndType(
+                        Name.ofString("reqAp"), JavaTypes.stringType())));
+
+    final Writer writer = generator.generate(pojo, defaultTestSettings(), javaWriter());
+
+    expect.toMatchSnapshot(writer.asString());
+  }
+
+  @Test
+  @SnapshotName("objectPojoWithRequiredNullableAdditionalProperty")
+  void generate_when_objectPojoWithRequiredNullableAdditionalProperty_then_correctOutput() {
+    final Generator<JavaObjectPojo, PojoSettings> generator = validationClassGenerator();
+
+    final JavaObjectPojo pojo =
+        sampleObjectPojo1()
+            .withRequiredAdditionalProperties(
+                PList.single(
+                    JavaRequiredAdditionalProperty.fromNameAndType(
+                        Name.ofString("reqAp"), JavaTypes.nullableStringType())));
+
+    final Writer writer = generator.generate(pojo, defaultTestSettings(), javaWriter());
+
+    expect.toMatchSnapshot(writer.asString());
+  }
+
+  @Test
+  @SnapshotName("objectPojoWithConstrainedRequiredNullableAdditionalProperty")
+  void
+      generate_when_objectPojoWithConstrainedRequiredNullableAdditionalProperty_then_correctOutput() {
+    final Generator<JavaObjectPojo, PojoSettings> generator = validationClassGenerator();
+
+    final JavaObjectPojo pojo =
+        sampleObjectPojo1()
+            .withRequiredAdditionalProperties(
+                PList.single(
+                    JavaRequiredAdditionalProperty.fromNameAndType(
+                        Name.ofString("reqAp"),
+                        JavaStringType.wrap(
+                            StringType.noFormat()
+                                .withNullability(Nullability.NULLABLE)
+                                .withConstraints(Constraints.empty().withSize(Size.of(3, 8))),
+                            TypeMappings.empty()))));
+
+    final Writer writer = generator.generate(pojo, defaultTestSettings(), javaWriter());
+
+    expect.toMatchSnapshot(writer.asString());
+  }
+
+  @Test
+  @SnapshotName("objectPojoWithObjectTypedRequiredNullableAdditionalProperty")
+  void
+      generate_when_objectPojoWithObjectTypedRequiredNullableAdditionalProperty_then_correctOutput() {
+    final Generator<JavaObjectPojo, PojoSettings> generator = validationClassGenerator();
+
+    final JavaObjectPojo pojo =
+        sampleObjectPojo1()
+            .withRequiredAdditionalProperties(
+                PList.single(
+                    JavaRequiredAdditionalProperty.fromNameAndType(
+                        Name.ofString("reqAp"),
+                        JavaObjectType.wrap(
+                            StandardObjectType.ofName(PojoName.ofName(Name.ofString("ApValueDto")))
+                                .withNullability(Nullability.NULLABLE),
+                            TypeMappings.empty()))));
 
     final Writer writer = generator.generate(pojo, defaultTestSettings(), javaWriter());
 

--- a/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/validation/validator/__snapshots__/ValidatorClassGeneratorTest.snap
+++ b/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/pojo/validation/validator/__snapshots__/ValidatorClassGeneratorTest.snap
@@ -130,6 +130,66 @@ private class Validator {
 ]
 
 
+objectPojoWithConstrainedRequiredNullableAdditionalProperty=[
+private class Validator {
+  private boolean isStringValValid() {
+    if(stringVal != null) {
+      return java.util.regex.Pattern.matches("Hello", stringVal);
+    }
+
+    return false;
+  }
+
+  private boolean isIntValValid() {
+    if(intVal != null) {
+      return 10L <= intVal
+          && intVal <= 50L;
+    }
+
+    return false;
+  }
+
+  private boolean isDoubleValValid() {
+    if(doubleVal != null) {
+      return 0 <= BigDecimal.valueOf(doubleVal).compareTo(new BigDecimal("12.5"))
+          && BigDecimal.valueOf(doubleVal).compareTo(new BigDecimal("50.1")) < 0;
+    }
+
+    return false;
+  }
+
+  private boolean isReqApValid() {
+    if(getReqAp().orElse(null) != null) {
+      return 3 <= getReqAp().orElse(null).length()
+          && getReqAp().orElse(null).length() <= 8;
+    }
+
+    return additionalProperties.containsKey("reqAp") && additionalProperties.get("reqAp") == null;
+  }
+
+  private boolean isAdditionalPropertiesValid() {
+    if(getAdditionalProperties_() != null) {
+      return getAdditionalProperties_().values().stream().allMatch(this::isAdditionalPropertiesValueValid);
+    }
+
+    return false;
+  }
+
+  private boolean isAdditionalPropertiesValueValid(Object additionalPropertiesValue) {
+    return true;
+  }
+
+  private boolean isValid() {
+    return isStringValValid()
+        && isIntValValid()
+        && isDoubleValValid()
+        && isReqApValid()
+        && isAdditionalPropertiesValid();
+  }
+}
+]
+
+
 objectPojoWithMaxPropertyCountConstraint=[
 private class Validator {
   private boolean isRequiredStringValValid() {
@@ -753,6 +813,175 @@ private class Validator {
         && isIntValValid()
         && isDoubleValValid()
         && isAllAdditionalPropertiesHaveCorrectType()
+        && isAdditionalPropertiesValid();
+  }
+}
+]
+
+
+objectPojoWithObjectTypedRequiredNullableAdditionalProperty=[
+private class Validator {
+  private boolean isStringValValid() {
+    if(stringVal != null) {
+      return java.util.regex.Pattern.matches("Hello", stringVal);
+    }
+
+    return false;
+  }
+
+  private boolean isIntValValid() {
+    if(intVal != null) {
+      return 10L <= intVal
+          && intVal <= 50L;
+    }
+
+    return false;
+  }
+
+  private boolean isDoubleValValid() {
+    if(doubleVal != null) {
+      return 0 <= BigDecimal.valueOf(doubleVal).compareTo(new BigDecimal("12.5"))
+          && BigDecimal.valueOf(doubleVal).compareTo(new BigDecimal("50.1")) < 0;
+    }
+
+    return false;
+  }
+
+  private boolean isReqApValid() {
+    if(getReqAp().orElse(null) != null) {
+      return getReqAp().orElse(null).isValid();
+    }
+
+    return additionalProperties.containsKey("reqAp") && additionalProperties.get("reqAp") == null;
+  }
+
+  private boolean isAdditionalPropertiesValid() {
+    if(getAdditionalProperties_() != null) {
+      return getAdditionalProperties_().values().stream().allMatch(this::isAdditionalPropertiesValueValid);
+    }
+
+    return false;
+  }
+
+  private boolean isAdditionalPropertiesValueValid(Object additionalPropertiesValue) {
+    return true;
+  }
+
+  private boolean isValid() {
+    return isStringValValid()
+        && isIntValValid()
+        && isDoubleValValid()
+        && isReqApValid()
+        && isAdditionalPropertiesValid();
+  }
+}
+]
+
+
+objectPojoWithRequiredNotNullableAdditionalProperty=[
+private class Validator {
+  private boolean isStringValValid() {
+    if(stringVal != null) {
+      return java.util.regex.Pattern.matches("Hello", stringVal);
+    }
+
+    return false;
+  }
+
+  private boolean isIntValValid() {
+    if(intVal != null) {
+      return 10L <= intVal
+          && intVal <= 50L;
+    }
+
+    return false;
+  }
+
+  private boolean isDoubleValValid() {
+    if(doubleVal != null) {
+      return 0 <= BigDecimal.valueOf(doubleVal).compareTo(new BigDecimal("12.5"))
+          && BigDecimal.valueOf(doubleVal).compareTo(new BigDecimal("50.1")) < 0;
+    }
+
+    return false;
+  }
+
+  private boolean isReqApValid() {
+    return getReqAp() != null;
+  }
+
+  private boolean isAdditionalPropertiesValid() {
+    if(getAdditionalProperties_() != null) {
+      return getAdditionalProperties_().values().stream().allMatch(this::isAdditionalPropertiesValueValid);
+    }
+
+    return false;
+  }
+
+  private boolean isAdditionalPropertiesValueValid(Object additionalPropertiesValue) {
+    return true;
+  }
+
+  private boolean isValid() {
+    return isStringValValid()
+        && isIntValValid()
+        && isDoubleValValid()
+        && isReqApValid()
+        && isAdditionalPropertiesValid();
+  }
+}
+]
+
+
+objectPojoWithRequiredNullableAdditionalProperty=[
+private class Validator {
+  private boolean isStringValValid() {
+    if(stringVal != null) {
+      return java.util.regex.Pattern.matches("Hello", stringVal);
+    }
+
+    return false;
+  }
+
+  private boolean isIntValValid() {
+    if(intVal != null) {
+      return 10L <= intVal
+          && intVal <= 50L;
+    }
+
+    return false;
+  }
+
+  private boolean isDoubleValValid() {
+    if(doubleVal != null) {
+      return 0 <= BigDecimal.valueOf(doubleVal).compareTo(new BigDecimal("12.5"))
+          && BigDecimal.valueOf(doubleVal).compareTo(new BigDecimal("50.1")) < 0;
+    }
+
+    return false;
+  }
+
+  private boolean isReqApValid() {
+    return additionalProperties.containsKey("reqAp") && (additionalProperties.get("reqAp") == null || getReqAp().orElse(null) != null);
+  }
+
+  private boolean isAdditionalPropertiesValid() {
+    if(getAdditionalProperties_() != null) {
+      return getAdditionalProperties_().values().stream().allMatch(this::isAdditionalPropertiesValueValid);
+    }
+
+    return false;
+  }
+
+  private boolean isAdditionalPropertiesValueValid(Object additionalPropertiesValue) {
+    return true;
+  }
+
+  private boolean isValid() {
+    return isStringValValid()
+        && isIntValValid()
+        && isDoubleValValid()
+        && isReqApValid()
         && isAdditionalPropertiesValid();
   }
 }

--- a/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/shared/validation/validator/__snapshots__/PropertyValidationGeneratorTest.snap
+++ b/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/shared/validation/validator/__snapshots__/PropertyValidationGeneratorTest.snap
@@ -314,7 +314,7 @@ requiredNullableStringWithoutCondition=[
 .
 .
 private boolean isStringValValid() {
-  return (stringVal != null || isStringValPresent);
+  return isStringValPresent;
 }
 ]
 

--- a/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/model/type/JavaTypes.java
+++ b/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/model/type/JavaTypes.java
@@ -1,6 +1,7 @@
 package com.github.muehmar.gradle.openapi.generator.java.model.type;
 
 import static com.github.muehmar.gradle.openapi.generator.model.Nullability.NOT_NULLABLE;
+import static com.github.muehmar.gradle.openapi.generator.model.Nullability.NULLABLE;
 
 import ch.bluecare.commons.data.PList;
 import com.github.muehmar.gradle.openapi.generator.model.constraints.Constraints;
@@ -22,6 +23,11 @@ public class JavaTypes {
     return JavaStringType.wrap(StringType.noFormat(), TypeMappings.empty());
   }
 
+  public static JavaStringType nullableStringType() {
+    return JavaStringType.wrap(
+        StringType.noFormat().withNullability(NULLABLE), TypeMappings.empty());
+  }
+
   public static JavaStringType date(Constraints constraints) {
     return JavaStringType.wrap(
         StringType.ofFormat(StringType.Format.DATE).withConstraints(constraints),
@@ -37,6 +43,11 @@ public class JavaTypes {
   public static JavaArrayType stringListType() {
     return JavaArrayType.wrap(
         ArrayType.ofItemType(StringType.noFormat(), NOT_NULLABLE), TypeMappings.empty());
+  }
+
+  public static JavaArrayType nullableStringListType() {
+    return JavaArrayType.wrap(
+        ArrayType.ofItemType(StringType.noFormat(), NULLABLE), TypeMappings.empty());
   }
 
   public static JavaBooleanType booleanType() {
@@ -64,7 +75,18 @@ public class JavaTypes {
         StandardObjectType.ofName(PojoName.ofName(Name.ofString("UserDto"))), TypeMappings.empty());
   }
 
+  public static JavaObjectType nullableObjectType() {
+    return JavaObjectType.wrap(
+        StandardObjectType.ofName(PojoName.ofName(Name.ofString("UserDto")))
+            .withNullability(NULLABLE),
+        TypeMappings.empty());
+  }
+
   public static JavaAnyType anyType() {
     return JavaAnyType.javaAnyType(NOT_NULLABLE);
+  }
+
+  public static JavaAnyType nullableAnyType() {
+    return JavaAnyType.javaAnyType(NULLABLE);
   }
 }


### PR DESCRIPTION
A required additional property whose value schema is nullable (e.g. `additionalProperties: { type: string, nullable: true }` with the key listed under `required`) produced uncompilable staged-builder code and an incorrect `@NotNull` validation constraint.

The staged builder emits an `Optional<T>` stage setter for any nullable required member, but RequiredAdditionalPropertiesSetterGenerator only generated the raw-typed Builder setter, so the delegation did not compile. It now also emits an `Optional<T>` Builder setter (marked `@JsonIgnore` to avoid a conflicting-setter clash with Jackson) for nullable required additional properties.

'required' now means only that the key is present: the validator's presence check uses `additionalProperties.containsKey(...)`, and the `@NotNull`/`...AsObject()` accessor is suppressed when the value schema is nullable, while the type check (which already permits null) remains.

The getter for a nullable required additional property now returns `Optional<T>` instead of a raw nullable value, consistent with how the rest of the DTO exposes nullable/optional data (never bare null). A not-nullable required additional property keeps its raw-typed getter. The typed getter casts via a lambda instead of a class literal so generic value types (e.g. array value schemas) compile.

Deep validation of a nullable object-typed value cascades through a separate raw-typed validation getter (`getXRaw()`, mirroring the member ValidationGetter convention) instead of a `@Valid` annotation on the Optional-returning getter, whose cascading is not guaranteed by the Bean Validation spec.

Issue: #394