### PR TITLE
chore: target version 5.0.0 and document the breaking changes of #394

### DIFF
--- a/doc/015_compatibility.md
+++ b/doc/015_compatibility.md
@@ -6,3 +6,4 @@
 | 2.x            | Java 8              |
 | 3.x            | Java 8              |
 | 4.x            | Java 11             |
+| 5.x            | Java 11             |

--- a/doc/120_migration_guides.md
+++ b/doc/120_migration_guides.md
@@ -1,3 +1,12 @@
+## Migrating from v4.x to 5.x
+
+### Breaking Changes
+
+* [#394](https://github.com/muehmar/gradle-openapi-schema/issues/394) - The getter of a required additional property
+  with a nullable value schema returns `Optional<T>` instead of the raw type. Additionally, `required` means only that
+  the key is present, i.e. a present but `null` value is valid now and no `@NotNull` constraint is generated for such a
+  property.
+
 ## Migrating from v3.x to 4.x
 
 ### Breaking Changes

--- a/doc/130_change_log.md
+++ b/doc/130_change_log.md
@@ -2,7 +2,8 @@
 
 * next
     * [#394](https://github.com/muehmar/gradle-openapi-schema/issues/394) - Fix uncompilable generated code and
-      incorrect validation for required additional properties with a nullable value schema
+      incorrect validation for required additional properties with a nullable value schema. This changes the generated
+      API for such a property, see the [migration guide](120_migration_guides.md#migrating-from-v4x-to-5x)
     * [#391](https://github.com/muehmar/gradle-openapi-schema/issues/391) - Coerce non-string enum literals to strings
       for `type: string` enums in OpenAPI 3.1 specs instead of failing with a `ClassCastException`
     * [#342](https://github.com/muehmar/gradle-openapi-schema/issues/342) - Support referenced files containing only

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=4.0.3-SNAPSHOT
+version=5.0.0-SNAPSHOT


### PR DESCRIPTION
The fix for #394 changes the generated API for required additional properties with a nullable value schema, so the next release is a new major version instead of 4.1.0.

Add a 'Migrating from v4.x to 5.x' section describing per issue what changed and how to adapt, reference it from the change log entry, and add 5.x to the compatibility table (unchanged minimum JDK 11).

Issue: #394