### PR TITLE
fix: derive the Jackson dialect of shared json code from both support…

### DIFF
--- a/doc/130_change_log.md
+++ b/doc/130_change_log.md
@@ -1,6 +1,10 @@
 ## Change Log
 
 * next
+    * [#385](https://github.com/muehmar/gradle-openapi-schema/issues/385) - Fix uncompilable generated code for
+      xml-only Jackson configs (`jsonSupport` 'none' combined with a Jackson `xmlSupport`)
+    * [#386](https://github.com/muehmar/gradle-openapi-schema/issues/386) - Reject mixing Jackson generations between
+      `jsonSupport` and `xmlSupport` with a clear error
     * [#408](https://github.com/muehmar/gradle-openapi-schema/issues/408) - Respect type mappings with conversion for
       required additional properties (the staged builder generated uncompilable code)
     * [#394](https://github.com/muehmar/gradle-openapi-schema/issues/394) - Fix uncompilable generated code and

--- a/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/java/generator/shared/jackson/JacksonZonedDateTimeDeserializerGenerator.java
+++ b/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/java/generator/shared/jackson/JacksonZonedDateTimeDeserializerGenerator.java
@@ -8,7 +8,6 @@ import ch.bluecare.commons.data.PList;
 import com.github.muehmar.gradle.openapi.generator.java.generator.shared.AnnotationGenerator;
 import com.github.muehmar.gradle.openapi.generator.java.ref.JacksonRefs;
 import com.github.muehmar.gradle.openapi.generator.java.ref.JavaRefs;
-import com.github.muehmar.gradle.openapi.generator.settings.JsonSupport;
 import com.github.muehmar.gradle.openapi.generator.settings.PojoSettings;
 import io.github.muehmar.codegenerator.Generator;
 import io.github.muehmar.codegenerator.java.JavaGenerators;
@@ -39,11 +38,7 @@ public class JacksonZonedDateTimeDeserializerGenerator {
         .append(JacksonRefs.generator(JacksonRefs::jsonDeserializerRef))
         .append(JacksonRefs.generator(JacksonRefs::jsonParserRef))
         .append(JacksonRefs.generator(JacksonRefs::deserializationContextRef))
-        .append(
-            (a, s, w) ->
-                s.getJsonSupport() == JsonSupport.JACKSON_2
-                    ? w.ref(JavaRefs.JAVA_IO_IOEXCEPTION)
-                    : w)
+        .append((a, s, w) -> s.usesJackson2() ? w.ref(JavaRefs.JAVA_IO_IOEXCEPTION) : w)
         .append(w -> w.ref(JavaRefs.JAVA_TIME_ZONED_DATE_TIME))
         .append(Writer::printRefs)
         .append(w -> w.println());
@@ -51,10 +46,7 @@ public class JacksonZonedDateTimeDeserializerGenerator {
 
   private static Generator<Void, PojoSettings> classDeclaration() {
     return (data, settings, writer) -> {
-      final String baseClass =
-          settings.getJsonSupport() == JsonSupport.JACKSON_2
-              ? "JsonDeserializer"
-              : "ValueDeserializer";
+      final String baseClass = settings.usesJackson2() ? "JsonDeserializer" : "ValueDeserializer";
       return writer.println(
           "public class %s extends %s<ZonedDateTime> {",
           ZONED_DATE_TIME_DESERIALIZER_CLASSNAME, baseClass);
@@ -64,9 +56,7 @@ public class JacksonZonedDateTimeDeserializerGenerator {
   private static Generator<Void, PojoSettings> deserializeMethod() {
     return (data, settings, writer) -> {
       final PList<String> exceptions =
-          settings.getJsonSupport() == JsonSupport.JACKSON_2
-              ? PList.of("IOException")
-              : PList.empty();
+          settings.usesJackson2() ? PList.of("IOException") : PList.empty();
 
       final Generator<Void, PojoSettings> method =
           JavaGenerators.<Void, PojoSettings>methodGen()
@@ -91,8 +81,7 @@ public class JacksonZonedDateTimeDeserializerGenerator {
   }
 
   private static Generator<Void, PojoSettings> deserializeMethodContent(PojoSettings settings) {
-    final String extractor =
-        settings.getJsonSupport() == JsonSupport.JACKSON_2 ? "p.getText()" : "p.getString()";
+    final String extractor = settings.usesJackson2() ? "p.getText()" : "p.getString()";
     return Generator.constant(String.format("return ZonedDateTime.parse(%s.trim());", extractor));
   }
 

--- a/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/java/ref/JacksonRefs.java
+++ b/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/java/ref/JacksonRefs.java
@@ -1,6 +1,5 @@
 package com.github.muehmar.gradle.openapi.generator.java.ref;
 
-import com.github.muehmar.gradle.openapi.generator.settings.JsonSupport;
 import com.github.muehmar.gradle.openapi.generator.settings.PojoSettings;
 import com.github.muehmar.gradle.openapi.generator.settings.XmlSupport;
 import io.github.muehmar.codegenerator.Generator;
@@ -65,9 +64,11 @@ public class JacksonRefs {
 
   private static String jsonRefString(
       PojoSettings settings, String jackson2RefSuffix, String jackson3RefSuffix) {
-    if (settings.getJsonSupport() == JsonSupport.JACKSON_2) {
+    // These refs are used for json as well as xml (Jackson XML reuses the databind annotations),
+    // so the dialect is derived from whichever support uses Jackson.
+    if (settings.usesJackson2()) {
       return "com.fasterxml." + jackson2RefSuffix;
-    } else if (settings.getJsonSupport() == JsonSupport.JACKSON_3) {
+    } else if (settings.usesJackson3()) {
       return "tools." + jackson3RefSuffix;
     } else {
       return "";

--- a/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/settings/PojoSettings.java
+++ b/plugin/src/main/java/com/github/muehmar/gradle/openapi/generator/settings/PojoSettings.java
@@ -49,6 +49,22 @@ public class PojoSettings implements Serializable {
     return xmlSupport.getGroup().equals(XmlSupportGroup.JACKSON);
   }
 
+  /**
+   * True if Jackson 2 is used for json, xml or both. Mixed Jackson generations are rejected by
+   * {@link #validate()}.
+   */
+  public boolean usesJackson2() {
+    return jsonSupport.equals(JsonSupport.JACKSON_2) || xmlSupport.equals(XmlSupport.JACKSON_2);
+  }
+
+  /**
+   * True if Jackson 3 is used for json, xml or both. Mixed Jackson generations are rejected by
+   * {@link #validate()}.
+   */
+  public boolean usesJackson3() {
+    return jsonSupport.equals(JsonSupport.JACKSON_3) || xmlSupport.equals(XmlSupport.JACKSON_3);
+  }
+
   public boolean isEnableValidation() {
     return enableValidation;
   }
@@ -133,6 +149,16 @@ public class PojoSettings implements Serializable {
   }
 
   public void validate() {
+    if ((jsonSupport.equals(JsonSupport.JACKSON_2) && xmlSupport.equals(XmlSupport.JACKSON_3))
+        || (jsonSupport.equals(JsonSupport.JACKSON_3) && xmlSupport.equals(XmlSupport.JACKSON_2))) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Mixing Jackson generations is not supported: jsonSupport '%s' and xmlSupport '%s' "
+                  + "would require the incompatible Jackson dialects com.fasterxml.* and tools.* "
+                  + "in the same generated sources. Use the same Jackson generation for both.",
+              jsonSupport.getValue(), xmlSupport.getValue()));
+    }
+
     classTypeMappings.forEach(
         classTypeMapping -> {
           if (not(classTypeMapping.getTypeConversion().isPresent())

--- a/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/shared/jackson/JacksonZonedDateTimeDeserializerGeneratorTest.java
+++ b/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/generator/shared/jackson/JacksonZonedDateTimeDeserializerGeneratorTest.java
@@ -2,11 +2,14 @@ package com.github.muehmar.gradle.openapi.generator.java.generator.shared.jackso
 
 import static com.github.muehmar.gradle.openapi.generator.java.generator.data.VoidData.noData;
 import static com.github.muehmar.gradle.openapi.generator.settings.TestPojoSettings.defaultTestSettings;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import au.com.origin.snapshots.Expect;
 import au.com.origin.snapshots.annotations.SnapshotName;
 import com.github.muehmar.gradle.openapi.generator.settings.JsonSupport;
 import com.github.muehmar.gradle.openapi.generator.settings.PojoSettings;
+import com.github.muehmar.gradle.openapi.generator.settings.XmlSupport;
 import com.github.muehmar.gradle.openapi.snapshot.SnapshotTest;
 import io.github.muehmar.codegenerator.Generator;
 import io.github.muehmar.codegenerator.writer.Writer;
@@ -40,5 +43,45 @@ class JacksonZonedDateTimeDeserializerGeneratorTest {
     final Writer writer = generator.generate(noData(), defaultTestSettings(), Writer.javaWriter());
 
     expect.toMatchSnapshot(writer.asString());
+  }
+
+  // Bug: the generator picks the Jackson dialect via getJsonSupport() alone. For the
+  // supported xml-only config (jsonSupport=NONE, xmlSupport=JACKSON_2) it therefore
+  // falls back to the Jackson-3 code shape (ValueDeserializer, p.getString()) and,
+  // because JacksonRefs#jsonRefString returns "" for jsonSupport=NONE, emits no
+  // Jackson imports at all. Desired: the Jackson-2 shape as in the
+  // zonedDateTimeDeserializerJackson2 snapshot.
+  @Test
+  void zonedDateTimeDeserializer_when_jsonSupportNoneAndXmlSupportJackson2_then_jackson2Shape() {
+    final Generator<Void, PojoSettings> generator =
+        JacksonZonedDateTimeDeserializerGenerator.zonedDateTimeDeserializer();
+
+    final Writer writer =
+        generator.generate(
+            noData(),
+            defaultTestSettings()
+                .withJsonSupport(JsonSupport.NONE)
+                .withXmlSupport(XmlSupport.JACKSON_2),
+            Writer.javaWriter());
+
+    final String output = writer.asString();
+
+    assertTrue(
+        output.contains("extends JsonDeserializer"),
+        "xml-only Jackson-2 config must generate the Jackson-2 base class but was:\n" + output);
+    assertFalse(
+        output.contains("extends ValueDeserializer"),
+        "xml-only Jackson-2 config must not generate the Jackson-3 base class but was:\n" + output);
+    assertTrue(
+        output.contains("p.getText()"),
+        "xml-only Jackson-2 config must use the Jackson-2 accessor p.getText() but was:\n"
+            + output);
+    assertFalse(
+        output.contains("p.getString()"),
+        "xml-only Jackson-2 config must not use the Jackson-3 accessor p.getString() but was:\n"
+            + output);
+    assertTrue(
+        output.contains("import com.fasterxml.jackson.databind.JsonDeserializer;"),
+        "xml-only Jackson-2 config must import the Jackson-2 JsonDeserializer but was:\n" + output);
   }
 }

--- a/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/ref/JacksonRefsTest.java
+++ b/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/java/ref/JacksonRefsTest.java
@@ -1,0 +1,114 @@
+package com.github.muehmar.gradle.openapi.generator.java.ref;
+
+import static com.github.muehmar.gradle.openapi.generator.settings.TestPojoSettings.defaultTestSettings;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.muehmar.gradle.openapi.generator.settings.JsonSupport;
+import com.github.muehmar.gradle.openapi.generator.settings.PojoSettings;
+import com.github.muehmar.gradle.openapi.generator.settings.XmlSupport;
+import org.junit.jupiter.api.Test;
+
+class JacksonRefsTest {
+
+  // ---------------------------------------------------------------------
+  // Green companion cases: explicit json support selects the dialect.
+  // ---------------------------------------------------------------------
+
+  @Test
+  void jsonRefs_when_jsonSupportJackson2_then_comFasterxmlRefs() {
+    final PojoSettings settings =
+        defaultTestSettings()
+            .withJsonSupport(JsonSupport.JACKSON_2)
+            .withXmlSupport(XmlSupport.NONE);
+
+    assertEquals(
+        "com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder",
+        JacksonRefs.jsonPojoBuilderRef(settings));
+    assertEquals(
+        "com.fasterxml.jackson.databind.annotation.JsonDeserialize",
+        JacksonRefs.jsonDeserializeRef(settings));
+    assertEquals(
+        "com.fasterxml.jackson.databind.JsonDeserializer",
+        JacksonRefs.jsonDeserializerRef(settings));
+    assertEquals("com.fasterxml.jackson.core.JsonParser", JacksonRefs.jsonParserRef(settings));
+    assertEquals(
+        "com.fasterxml.jackson.databind.DeserializationContext",
+        JacksonRefs.deserializationContextRef(settings));
+  }
+
+  @Test
+  void jsonRefs_when_jsonSupportJackson3_then_toolsRefs() {
+    final PojoSettings settings =
+        defaultTestSettings()
+            .withJsonSupport(JsonSupport.JACKSON_3)
+            .withXmlSupport(XmlSupport.NONE);
+
+    assertEquals(
+        "tools.jackson.databind.annotation.JsonPOJOBuilder",
+        JacksonRefs.jsonPojoBuilderRef(settings));
+    assertEquals(
+        "tools.jackson.databind.annotation.JsonDeserialize",
+        JacksonRefs.jsonDeserializeRef(settings));
+    assertEquals(
+        "tools.jackson.databind.ValueDeserializer", JacksonRefs.jsonDeserializerRef(settings));
+    assertEquals("tools.jackson.core.JsonParser", JacksonRefs.jsonParserRef(settings));
+    assertEquals(
+        "tools.jackson.databind.DeserializationContext",
+        JacksonRefs.deserializationContextRef(settings));
+  }
+
+  // ---------------------------------------------------------------------
+  // Red cases: xml-only Jackson configs must still produce the json refs.
+  //
+  // Bug: JacksonRefs#jsonRefString keys on getJsonSupport() alone and
+  // returns "" for jsonSupport=NONE, even though
+  // PojoSettings#isJacksonJson() deliberately returns true when only
+  // xmlSupport is Jackson (Jackson XML uses the databind annotations).
+  // As a result, xml-only configs emit Jackson annotations WITHOUT the
+  // corresponding imports. The json refs must fall back to the xml
+  // support's Jackson generation.
+  // ---------------------------------------------------------------------
+
+  @Test
+  void jsonRefs_when_jsonSupportNoneAndXmlSupportJackson2_then_comFasterxmlRefs() {
+    final PojoSettings settings =
+        defaultTestSettings()
+            .withJsonSupport(JsonSupport.NONE)
+            .withXmlSupport(XmlSupport.JACKSON_2);
+
+    assertEquals(
+        "com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder",
+        JacksonRefs.jsonPojoBuilderRef(settings));
+    assertEquals(
+        "com.fasterxml.jackson.databind.annotation.JsonDeserialize",
+        JacksonRefs.jsonDeserializeRef(settings));
+    assertEquals(
+        "com.fasterxml.jackson.databind.JsonDeserializer",
+        JacksonRefs.jsonDeserializerRef(settings));
+    assertEquals("com.fasterxml.jackson.core.JsonParser", JacksonRefs.jsonParserRef(settings));
+    assertEquals(
+        "com.fasterxml.jackson.databind.DeserializationContext",
+        JacksonRefs.deserializationContextRef(settings));
+  }
+
+  @Test
+  void jsonRefs_when_jsonSupportNoneAndXmlSupportJackson3_then_toolsRefs() {
+    final PojoSettings settings =
+        defaultTestSettings()
+            .withJsonSupport(JsonSupport.NONE)
+            .withXmlSupport(XmlSupport.JACKSON_3);
+
+    assertEquals(
+        "tools.jackson.databind.annotation.JsonPOJOBuilder",
+        JacksonRefs.jsonPojoBuilderRef(settings));
+    assertEquals(
+        "tools.jackson.databind.annotation.JsonDeserialize",
+        JacksonRefs.jsonDeserializeRef(settings));
+    assertEquals(
+        "tools.jackson.databind.ValueDeserializer", JacksonRefs.jsonDeserializerRef(settings));
+    assertEquals("tools.jackson.core.JsonParser", JacksonRefs.jsonParserRef(settings));
+    assertEquals(
+        "tools.jackson.databind.DeserializationContext",
+        JacksonRefs.deserializationContextRef(settings));
+  }
+}

--- a/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/settings/PojoSettingsTest.java
+++ b/plugin/src/test/java/com/github/muehmar/gradle/openapi/generator/settings/PojoSettingsTest.java
@@ -1,7 +1,9 @@
 package com.github.muehmar.gradle.openapi.generator.settings;
 
 import static com.github.muehmar.gradle.openapi.generator.model.name.PojoNames.pojoName;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.github.muehmar.gradle.openapi.generator.model.name.PojoName;
 import java.util.stream.Collectors;
@@ -27,5 +29,66 @@ class PojoSettingsTest {
     final PojoName mappedPojoName = pojoNameMapping.map(pojoName);
 
     assertEquals("PersonDto", mappedPojoName.asString());
+  }
+
+  // Bug: validate() accepts mixed Jackson generations. jsonSupport=JACKSON_2 combined
+  // with xmlSupport=JACKSON_3 (and vice versa) would require conflicting Jackson
+  // dialects (com.fasterxml.* vs tools.*) in the same generated sources and must be
+  // rejected. Note: validate() currently only registers warnings and never throws;
+  // IllegalArgumentException is asserted here since that is how other fatal config
+  // errors are raised (e.g. unsupported values in SingleSchemaExtension).
+  @Test
+  void validate_when_jsonSupportJackson2AndXmlSupportJackson3_then_throws() {
+    final PojoSettings settings =
+        TestPojoSettings.defaultTestSettings()
+            .withJsonSupport(JsonSupport.JACKSON_2)
+            .withXmlSupport(XmlSupport.JACKSON_3);
+
+    assertThrows(IllegalArgumentException.class, settings::validate);
+  }
+
+  // Bug: same as above, opposite direction (jsonSupport=JACKSON_3, xmlSupport=JACKSON_2).
+  @Test
+  void validate_when_jsonSupportJackson3AndXmlSupportJackson2_then_throws() {
+    final PojoSettings settings =
+        TestPojoSettings.defaultTestSettings()
+            .withJsonSupport(JsonSupport.JACKSON_3)
+            .withXmlSupport(XmlSupport.JACKSON_2);
+
+    assertThrows(IllegalArgumentException.class, settings::validate);
+  }
+
+  @Test
+  void validate_when_sameOrNoJacksonGenerations_then_doesNotThrow() {
+    assertDoesNotThrow(
+        () ->
+            TestPojoSettings.defaultTestSettings()
+                .withJsonSupport(JsonSupport.JACKSON_2)
+                .withXmlSupport(XmlSupport.JACKSON_2)
+                .validate());
+    assertDoesNotThrow(
+        () ->
+            TestPojoSettings.defaultTestSettings()
+                .withJsonSupport(JsonSupport.JACKSON_3)
+                .withXmlSupport(XmlSupport.JACKSON_3)
+                .validate());
+    assertDoesNotThrow(
+        () ->
+            TestPojoSettings.defaultTestSettings()
+                .withJsonSupport(JsonSupport.NONE)
+                .withXmlSupport(XmlSupport.JACKSON_2)
+                .validate());
+    assertDoesNotThrow(
+        () ->
+            TestPojoSettings.defaultTestSettings()
+                .withJsonSupport(JsonSupport.JACKSON_3)
+                .withXmlSupport(XmlSupport.NONE)
+                .validate());
+    assertDoesNotThrow(
+        () ->
+            TestPojoSettings.defaultTestSettings()
+                .withJsonSupport(JsonSupport.NONE)
+                .withXmlSupport(XmlSupport.NONE)
+                .validate());
   }
 }


### PR DESCRIPTION
…s and reject mixed generations

xml-only configs (jsonSupport 'none' with a Jackson xmlSupport) generated the json annotations reused by Jackson XML without imports and the ZonedDateTime deserializer in the wrong dialect, both uncompilable. The json refs and the deserializer are used for json as well as xml, so their dialect is now derived from whichever support uses Jackson via the new PojoSettings.usesJackson2()/usesJackson3().

Mixing Jackson generations (jsonSupport 'jackson-2' with xmlSupport 'jackson-3' or vice versa) was silently accepted although the generated sources would mix com.fasterxml.* and tools.* annotations. This is now rejected in PojoSettings.validate() with a clear error.

Issue: #385
Issue: #386